### PR TITLE
Add automatic rotation of images that contain orientation data

### DIFF
--- a/src/decoders/arw.rs
+++ b/src/decoders/arw.rs
@@ -73,7 +73,7 @@ impl<'a> Decoder for ArwDecoder<'a> {
 }
 
 impl<'a> ArwDecoder<'a> {
-  fn image_a100(&self, camera: &Camera) -> Result<RawImage,String> {
+  fn image_a100(&self, camera: Camera) -> Result<RawImage,String> {
     // We've caught the elusive A100 in the wild, a transitional format
     // between the simple sanity of the MRW custom format and the wordly
     // wonderfullness of the Tiff-based ARW format, let's shoot from the hip
@@ -110,7 +110,7 @@ impl<'a> ArwDecoder<'a> {
     ok_image(camera, width, height, wb_coeffs, image)
   }
 
-  fn image_srf(&self, camera: &Camera) -> Result<RawImage,String> {
+  fn image_srf(&self, camera: Camera) -> Result<RawImage,String> {
     let data = self.tiff.find_ifds_with_tag(Tag::ImageWidth);
     if data.len() == 0 {
       return Err("ARW: Couldn't find the data IFD!".to_string())

--- a/src/decoders/cr2.rs
+++ b/src/decoders/cr2.rs
@@ -66,7 +66,7 @@ impl<'a> Decoder for Cr2Decoder<'a> {
 
       // Convert the YUV in sRAWs to RGB
       if cpp == 3 {
-        try!(self.convert_to_rgb(camera, &mut ljpegout));
+        try!(self.convert_to_rgb(&camera, &mut ljpegout));
         if raw.has_entry(Tag::ImageWidth) {
           width = fetch_tag!(raw, Tag::ImageWidth).get_usize(0) * cpp;
           height = fetch_tag!(raw, Tag::ImageLength).get_usize(0) ;
@@ -142,7 +142,8 @@ impl<'a> Decoder for Cr2Decoder<'a> {
       }
     };
 
-    let mut img = RawImage::new(camera, width, height, try!(self.get_wb(camera)), image);
+    let wb = self.get_wb(&camera)?;
+    let mut img = RawImage::new(camera, width, height, wb, image);
     if cpp == 3 {
       img.cpp = 3;
       img.width /= 3;

--- a/src/decoders/crw.rs
+++ b/src/decoders/crw.rs
@@ -149,10 +149,11 @@ impl<'a> Decoder for CrwDecoder<'a> {
       let sensorinfo = fetch_tag!(self.ciff, CiffTag::SensorInfo);
       let width = sensorinfo.get_usize(1);
       let height = sensorinfo.get_usize(2);
-      (width, height, try!(self.decode_compressed(camera, width, height)))
+      (width, height, try!(self.decode_compressed(&camera, width, height)))
     };
 
-    ok_image(camera, width, height, try!(self.get_wb(camera)), image)
+    let wb = self.get_wb(&camera)?;
+    ok_image(camera, width, height, wb, image)
   }
 }
 

--- a/src/decoders/dng.rs
+++ b/src/decoders/dng.rs
@@ -54,11 +54,7 @@ impl<'a> Decoder for DngDecoder<'a> {
         Err(_) => {
           let make = fetch_tag!(self.tiff, Tag::Make).get_str();
           let model = fetch_tag!(self.tiff, Tag::Model).get_str();
-          let orientation = if let Some(ifd) = self.tiff.find_first_ifd(Tag::Orientation) {
-            Orientation::from_u16(ifd.find_entry(Tag::Orientation).unwrap().get_usize(0) as u16)
-          } else {
-            Orientation::Unknown
-          };
+          let orientation = Orientation::from_tiff(&self.tiff);
           (make.to_string(), model.to_string(), make.to_string(), model.to_string(), orientation)
         },
       }

--- a/src/decoders/image.rs
+++ b/src/decoders/image.rs
@@ -32,6 +32,8 @@ pub struct RawImage {
   pub cfa: CFA,
   /// how much to crop the image to get all the usable area, order is top, right, bottom, left
   pub crops: [usize;4],
+  /// orientation of the image as indicated by the image metadata
+  pub orientation: Orientation,
   /// image data itself, has width*height*cpp elements
   pub data: Vec<u16>,
 }
@@ -60,7 +62,7 @@ pub struct SRGBImage {
 
 
 impl RawImage {
-  #[doc(hidden)] pub fn new(camera: &Camera, width: usize, height: usize, wb_coeffs: [f32;4], image: Vec<u16>) -> RawImage {
+  #[doc(hidden)] pub fn new(camera: Camera, width: usize, height: usize, wb_coeffs: [f32;4], image: Vec<u16>) -> RawImage {
     let blacks = if camera.blackareah.1 != 0 || camera.blackareav.1 != 0 {
       let mut avg = [0 as f32; 4];
       let mut count = [0 as f32; 4];
@@ -101,6 +103,7 @@ impl RawImage {
       xyz_to_cam: camera.xyz_to_cam,
       cfa: camera.cfa.clone(),
       crops: camera.crops,
+      orientation: camera.orientation,
     }
   }
 

--- a/src/decoders/mos.rs
+++ b/src/decoders/mos.rs
@@ -43,7 +43,7 @@ impl<'a> Decoder for MosDecoder<'a> {
         }
       },
       7 | 99 => {
-        try!(self.decode_compressed(camera, src, width, height))
+        try!(self.decode_compressed(&camera, src, width, height))
       },
       x => return Err(format!("MOS: unsupported compression {}", x).to_string())
     };

--- a/src/decoders/nkd.rs
+++ b/src/decoders/nkd.rs
@@ -6,11 +6,11 @@ use std::f32::NAN;
 pub struct NakedDecoder<'a> {
   buffer: &'a [u8],
   rawloader: &'a RawLoader,
-  camera: &'a Camera,
+  camera: Camera,
 }
 
 impl<'a> NakedDecoder<'a> {
-  pub fn new(buf: &'a [u8], cam: &'a Camera, rawloader: &'a RawLoader) -> NakedDecoder<'a> {
+  pub fn new(buf: &'a [u8], cam: Camera, rawloader: &'a RawLoader) -> NakedDecoder<'a> {
     NakedDecoder {
       buffer: buf,
       camera: cam,
@@ -36,6 +36,6 @@ impl<'a> Decoder for NakedDecoder<'a> {
       }
     };
 
-    ok_image(self.camera, width, height, [NAN,NAN,NAN,NAN], image)
+    ok_image(self.camera.clone(), width, height, [NAN,NAN,NAN,NAN], image)
   }
 }

--- a/src/decoders/nrw.rs
+++ b/src/decoders/nrw.rs
@@ -40,7 +40,8 @@ impl<'a> Decoder for NrwDecoder<'a> {
       decode_12be(src, width, height)
     };
 
-    ok_image(camera, width, height, try!(self.get_wb(camera)), image)
+    let wb = self.get_wb(&camera)?;
+    ok_image(camera, width, height, wb, image)
   }
 }
 

--- a/src/decoders/raf.rs
+++ b/src/decoders/raf.rs
@@ -61,7 +61,7 @@ impl<'a> Decoder for RafDecoder<'a> {
     };
 
     if camera.find_hint("fuji_rotation") || camera.find_hint("fuji_rotation_alt") {
-      let (width, height, image) = RafDecoder::rotate_image(&image, camera, width, height);
+      let (width, height, image) = RafDecoder::rotate_image(&image, &camera, width, height);
       Ok(RawImage {
         make: camera.make.clone(),
         model: camera.model.clone(),
@@ -77,6 +77,7 @@ impl<'a> Decoder for RafDecoder<'a> {
         xyz_to_cam: camera.xyz_to_cam,
         cfa: camera.cfa.clone(),
         crops: [0,0,0,0],
+        orientation: camera.orientation,
       })
     } else {
       ok_image(camera, width, height, try!(self.get_wb()), image)

--- a/src/decoders/tiff.rs
+++ b/src/decoders/tiff.rs
@@ -31,6 +31,7 @@ pub enum Tag {
   Make             = 0x010F,
   Model            = 0x0110,
   StripOffsets     = 0x0111,
+  Orientation      = 0x0112,
   SamplesPerPixel  = 0x0115,
   StripByteCounts  = 0x0117,
   PanaOffsets      = 0x0118,
@@ -91,6 +92,7 @@ pub enum Tag {
   KdcIFD           = 0xFE00,
 }
 }
+
                           // 0-1-2-3-4-5-6-7-8-9-10-11-12-13
 const DATASHIFTS: [u8;14] = [0,0,0,1,2,3,0,0,1,2, 3, 2, 3, 2];
 

--- a/src/imageops/transform.rs
+++ b/src/imageops/transform.rs
@@ -1,0 +1,64 @@
+extern crate rayon;
+use self::rayon::prelude::*;
+
+use decoders::RawImage;
+use imageops::OpBuffer;
+
+/// Mirror an OpBuffer horizontally
+pub fn flip_horizontal(buf: &OpBuffer) -> OpBuffer {
+  let mut out = OpBuffer::new(buf.width, buf.height, buf.colors);
+  out.data.par_chunks_mut(out.width * out.colors).enumerate().for_each(|(row, line)| {
+    let offset = buf.width * row * buf.colors;
+    for col in 0 .. buf.width {
+      for c in 0 .. buf.colors {
+        line[col * buf.colors + c] = buf.data[offset + (buf.width - 1 - col) * buf.colors + c];
+      }
+    }
+  });
+
+  out
+}
+
+/// Mirror an OpBuffer vertically
+pub fn flip_vertical(buf: &OpBuffer) -> OpBuffer {
+  let mut out = OpBuffer::new(buf.width, buf.height, buf.colors);
+  out.data.par_chunks_mut(out.width * out.colors).enumerate().for_each(|(row, line)| {
+    let offset = (buf.height - 1 - row) * buf.width * buf.colors;
+    for col in 0 .. buf.width * buf.colors {
+      line[col] = buf.data[offset + col];
+    }
+  });
+
+  out
+}
+
+/// Transpose an OpBuffer
+pub fn transpose(buf: &OpBuffer) -> OpBuffer {
+  let mut out = OpBuffer::new(buf.height, buf.width, buf.colors);
+
+  out.data.par_chunks_mut(out.width * out.colors).enumerate().for_each(|(row, line)| {
+    for col in 0 .. buf.height {
+      let target = col * buf.colors;
+      let source = (col * buf.width + row) * buf.colors;
+      for c in 0 .. buf.colors {
+        line[target + c] = buf.data[source + c];
+      }
+    }
+  });
+
+  out
+}
+
+/// Rotate an OpBuffer based on the given RawImage's orientation
+pub fn rotate(img: &RawImage, buf: &OpBuffer) -> OpBuffer {
+  match img.orientation.to_flips() {
+    (false, false, false) => buf.clone(),
+    (false, false, true) => flip_vertical(buf),
+    (false, true, false) => flip_horizontal(buf),
+    (false, true, true) => flip_horizontal(&flip_vertical(buf)),
+    (true, false, false) => transpose(buf),
+    (true, false, true) => flip_vertical(&transpose(buf)),
+    (true, true, false) => flip_horizontal(&transpose(buf)),
+    (true, true, true) => flip_vertical(&transpose(&flip_horizontal(buf))),
+  }
+}


### PR DESCRIPTION
I have added automatic rotation when decoding a `RawImage`. Right now it is implemented as a separate image operation rather than being part of the demosaic step. I have experimented with in-situ rotation vs creating a new `OpBuffer` and found creating a new one to be more performant due to that it is easy to use `rayon`'s parallell iterators.

Criticism is welcome.