### PR TITLE
Error Message With Full UTF Character (instead of only first UTF byte)

### DIFF
--- a/src/decoders/cfa.rs
+++ b/src/decoders/cfa.rs
@@ -54,7 +54,7 @@ impl CFA {
       36 => (6,6),
       16 => (2,8),
       144 => (12,12),
-      _ => panic!(format!("Unknown CFA size \"{}\"", patname).to_string()),
+      _ => panic!("Unknown CFA size \"{}\"", patname),
     };
     let mut pattern: [[usize;48];48] = [[0;48];48];
 
@@ -131,7 +131,7 @@ impl CFA {
           1 => "G",
           2 => "B",
           3 => "E",
-          x => panic!(format!("Unknown CFA color \"{}\"", x).to_string()),
+          x => panic!("Unknown CFA color \"{}\"", x),
         });
       }
     }

--- a/src/decoders/cfa.rs
+++ b/src/decoders/cfa.rs
@@ -68,7 +68,7 @@ impl CFA {
           b'E' => 3,
           b'M' => 1,
           b'Y' => 3,
-          _   => panic!(format!("Unknown CFA color \"{}\"", c).to_string()),
+          _    => panic!("Unknown CFA color \"{}\"", c),
         };
       }
 

--- a/src/decoders/cfa.rs
+++ b/src/decoders/cfa.rs
@@ -68,7 +68,10 @@ impl CFA {
           b'E' => 3,
           b'M' => 1,
           b'Y' => 3,
-          _    => panic!("Unknown CFA color \"{}\"", c),
+          _    => {
+              let unknown_char = patname[i..].chars().next().unwrap();
+              panic!("Unknown CFA color \"{}\" in pattern \"{}\"", unknown_char, patname)
+          },
         };
       }
 


### PR DESCRIPTION
When, for example, instantiating a CFA with the pattern "RGü", where 'ü' consists of two bytes, the error message would print only the first byte of 'ü'.

In this pull request, the error message contains the full unknown character and also prints the whole pattern containing the character.

Also, I simplified all panic message formatting in this file.