### PR TITLE
CFA Result instead of panic

### DIFF
--- a/src/decoders/cfa.rs
+++ b/src/decoders/cfa.rs
@@ -17,6 +17,7 @@ use std::fmt;
 /// initialized and ready to be used in processing. The color_at() implementation is
 /// designed to be fast so it can be called inside the inner loop of demosaic or other
 /// color-aware algorithms that work on pre-demosaic data
+#[derive(Clone)]
 pub struct CFA {
   pub name: String,
   pub width: usize,
@@ -181,22 +182,5 @@ impl CFA {
 impl fmt::Debug for CFA {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     write!(f, "CFA {{ {} }}", self.name)
-  }
-}
-
-impl Clone for CFA {
-  fn clone(&self) -> CFA {
-    let mut cpattern: [[usize;48];48] = [[0;48];48];
-    for row in 0..48 {
-      for col in 0..48 {
-        cpattern[row][col] = self.pattern[row][col];
-      }
-    }
-    CFA {
-      name: self.name.clone(),
-      pattern: cpattern,
-      width: self.width,
-      height: self.height,
-    }
   }
 }

--- a/src/decoders/cfa.rs
+++ b/src/decoders/cfa.rs
@@ -73,7 +73,7 @@ impl CFA {
           b'Y' => 3,
           _    => {
               let unknown_char = patname[i..].chars().next().unwrap();
-              panic!("Unknown CFA color \"{}\" in pattern \"{}\"", unknown_char, patname);
+              panic!("Unknown CFA color \"{}\" in pattern \"{}\"", unknown_char, patname)
           },
         };
       }
@@ -135,7 +135,7 @@ impl CFA {
           1 => "G",
           2 => "B",
           3 => "E",
-          x => panic!("Unknown CFA color \"{}\"", x), // should only happen when deserializing an invalid cfa
+          x => panic!("Unknown CFA color \"{}\"", x),
         });
       }
     }

--- a/src/decoders/dng.rs
+++ b/src/decoders/dng.rs
@@ -111,7 +111,7 @@ impl<'a> DngDecoder<'a> {
 
   fn get_cfa(&self, raw: &TiffIFD) -> Result<CFA,String> {
     let pattern = fetch_tag!(raw, Tag::CFAPattern);
-    Ok(CFA::new_from_tag(pattern))
+    CFA::new_from_tag(pattern)
   }
 
   fn get_crops(&self, raw: &TiffIFD, width: usize, height: usize) -> Result<[usize;4],String> {

--- a/src/imageops/ops/demosaic.rs
+++ b/src/imageops/ops/demosaic.rs
@@ -4,7 +4,7 @@ use imageops::*;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OpDemosaic {
-  cfa: String,
+  cfa: String, // it's a string because of simpler serialization
 }
 
 impl OpDemosaic {


### PR DESCRIPTION
Made `CFA::new_from_tag` return a Result<CFA, String> instead of panicking when encountering an invalid tiff tag cfa color.

Also simplified CFA::clone by using a derive instead of manual copying.