### PR TITLE
replace enum_primitive with enum-repr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ build = "data/cameras/join.rs"
 [dependencies]
 toml = "0.5"
 time = "0.2"
-enum_primitive = "0.1"
+enum-repr = "0.2.5"
 num = "0.2"
 lazy_static = "1"
 byteorder = "1"

--- a/src/decoders/ciff.rs
+++ b/src/decoders/ciff.rs
@@ -1,10 +1,8 @@
-use enum_primitive::{enum_from_primitive, enum_from_primitive_impl, enum_from_primitive_impl_ty};
 use std::collections::HashMap;
 
 use crate::decoders::basics::*;
 use crate::decoders::Buffer;
 
-enum_from_primitive! {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum CiffTag {
   Null         = 0x0000,
@@ -19,7 +17,6 @@ pub enum CiffTag {
   RawData      = 0x2005,
   SubIFD       = 0x300a,
   Exif         = 0x300b,
-}
 }
 
 fn ct (tag: CiffTag) -> u16 {

--- a/src/decoders/tiff.rs
+++ b/src/decoders/tiff.rs
@@ -1,11 +1,11 @@
-use enum_primitive::{enum_from_primitive, enum_from_primitive_impl, enum_from_primitive_impl_ty};
 use num::FromPrimitive;
+use enum_repr::EnumRepr;
 use std::collections::HashMap;
 use std::str;
 
 use crate::decoders::basics::*;
 
-enum_from_primitive! {
+#[EnumRepr(type = "u16")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Tag {
   PanaWidth        = 0x0002,
@@ -95,7 +95,6 @@ pub enum Tag {
   KdcLength        = 0xFD01,
   KdcOffset        = 0xFD04,
   KdcIFD           = 0xFE00,
-}
 }
 
                           // 0-1-2-3-4-5-6-7-8-9-10-11-12-13
@@ -202,7 +201,7 @@ impl<'a> TiffIFD<'a> {
     }
     for i in 0..num {
       let entry_offset: usize = offset + 2 + (i as usize)*12;
-      if Tag::from_u16(e.ru16(buf, entry_offset)).is_none() {
+      if Tag::from_repr(e.ru16(buf, entry_offset)).is_none() {
         // Skip entries we don't know about to speedup decoding
         continue;
       }


### PR DESCRIPTION
In an effort to reduce duplicate crate versions in projects, replace the unmaintained `enum_primitive` crate which depends on an old version of `num-traits` with `enum-repr`.