### PR TITLE
Tweak documentation for RawImage::data

### DIFF
--- a/src/decoders/image.rs
+++ b/src/decoders/image.rs
@@ -38,7 +38,7 @@ pub struct RawImage {
 
   /// orientation of the image as indicated by the image metadata
   pub orientation: Orientation,
-  /// image data itself, has width*height*cpp elements
+  /// image data itself, has `width`\*`height`\*`cpp` elements
   pub data: RawImageData,
 }
 


### PR DESCRIPTION
Previously the asterisks (*) in the comments of RawImage::data was incorrectly
interpreted as formatting characters by docs.rs, making the documentation
for this field confusing to read.

It has been fixed by adding escaping before asterisks. Also tweaked formats of
other mentioned fields in the comments to make them more obvious.