### PR TITLE
Upgrade to Rust 2018, fix deprecation warnings and errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://docs.rs/rawloader/"
 repository = "https://github.com/pedrocr/rawloader"
 license = "LGPL-2.1"
 categories = ["multimedia::images"]
+edition = "2018"
 
 build = "data/cameras/join.rs"
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufWriter;
 
-extern crate rawloader;
-
 fn main() {
   let args: Vec<_> = env::args().collect();
   if args.len() != 2 {

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -2,9 +2,6 @@ use std::env;
 use std::fs::File;
 use std::error::Error;
 
-extern crate rawloader;
-extern crate time;
-
 fn usage() {
   println!("benchmark <file>");
   std::process::exit(1);

--- a/src/bin/identify.rs
+++ b/src/bin/identify.rs
@@ -1,5 +1,3 @@
-extern crate rawloader;
-
 use std::env;
 
 fn main() {

--- a/src/decoders/ari.rs
+++ b/src/decoders/ari.rs
@@ -1,6 +1,7 @@
-use decoders::*;
-use decoders::basics::*;
 use std::f32::NAN;
+
+use crate::decoders::*;
+use crate::decoders::basics::*;
 
 pub fn is_ari(buf: &[u8]) -> bool {
   buf[0..4] == b"ARRI"[..]
@@ -27,12 +28,12 @@ impl<'a> Decoder for AriDecoder<'a> {
     let width = LEu32(self.buffer, 20) as usize;
     let height = LEu32(self.buffer, 24) as usize;
     let model = String::from_utf8_lossy(&self.buffer[668..]).split_terminator("\0").next().unwrap_or("").to_string();
-    let camera = try!(self.rawloader.check_supported_with_everything("ARRI", &model, ""));
+    let camera = self.rawloader.check_supported_with_everything("ARRI", &model, "")?;
     let src = &self.buffer[offset..];
 
     let image = decode_12be_msb32(src, width, height, dummy);
 
-    ok_image(camera, width, height, try!(self.get_wb()), image)
+    ok_image(camera, width, height, self.get_wb()?, image)
   }
 }
 

--- a/src/decoders/basics.rs
+++ b/src/decoders/basics.rs
@@ -1,11 +1,8 @@
-extern crate rayon;
-use self::rayon::prelude::*;
+use byteorder::{BigEndian, LittleEndian, ByteOrder};
+use rayon::prelude::*;
 
-extern crate byteorder;
-use self::byteorder::{BigEndian, LittleEndian, ByteOrder};
-
-pub use decoders::packed::*;
-pub use decoders::pumps::*;
+pub use crate::decoders::packed::*;
+pub use crate::decoders::pumps::*;
 
 pub fn clampbits(val: i32, bits: u32) -> i32 {
   let temp = val >> bits;

--- a/src/decoders/cfa.rs
+++ b/src/decoders/cfa.rs
@@ -1,5 +1,6 @@
-use decoders::tiff::*;
 use std::fmt;
+
+use crate::decoders::tiff::*;
 
 /// Representation of the color filter array pattern in raw cameras
 ///

--- a/src/decoders/ciff.rs
+++ b/src/decoders/ciff.rs
@@ -1,6 +1,8 @@
+use enum_primitive::{enum_from_primitive, enum_from_primitive_impl, enum_from_primitive_impl_ty};
 use std::collections::HashMap;
-use decoders::basics::*;
-use decoders::Buffer;
+
+use crate::decoders::basics::*;
+use crate::decoders::Buffer;
 
 enum_from_primitive! {
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -59,7 +61,7 @@ impl<'a> CiffIFD<'a> {
 
     for i in 0..dircount {
       let entry_offset: usize = start+valuedata_size+2+i*10;
-      let e = try!(CiffEntry::new(buf, start, entry_offset));
+      let e = CiffEntry::new(buf, start, entry_offset)?;
       if e.typ == 0x2800 || e.typ == 0x3000 { // SubIFDs
         if depth < 10 { // Avoid infinite looping IFDs
           let ifd = CiffIFD::new(buf, e.data_offset, e.data_offset+e.bytesize, depth+1);

--- a/src/decoders/dcr.rs
+++ b/src/decoders/dcr.rs
@@ -1,8 +1,9 @@
-use decoders::*;
-use decoders::tiff::*;
-use decoders::basics::*;
 use std::f32::NAN;
 use std::cmp;
+
+use crate::decoders::*;
+use crate::decoders::tiff::*;
+use crate::decoders::basics::*;
 
 #[derive(Debug, Clone)]
 pub struct DcrDecoder<'a> {
@@ -23,7 +24,7 @@ impl<'a> DcrDecoder<'a> {
 
 impl<'a> Decoder for DcrDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
-    let camera = try!(self.rawloader.check_supported(&self.tiff));
+    let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, Tag::CFAPattern);
     let width = fetch_tag!(raw, Tag::ImageWidth).get_usize(0);
     let height = fetch_tag!(raw, Tag::ImageLength).get_usize(0);
@@ -41,7 +42,7 @@ impl<'a> Decoder for DcrDecoder<'a> {
 
     let image = DcrDecoder::decode_kodak65000(src, &curve, width, height, dummy);
 
-    ok_image(camera, width, height, try!(self.get_wb()), image)
+    ok_image(camera, width, height, self.get_wb()?, image)
   }
 }
 

--- a/src/decoders/dcs.rs
+++ b/src/decoders/dcs.rs
@@ -1,7 +1,8 @@
-use decoders::*;
-use decoders::tiff::*;
-use decoders::basics::*;
 use std::f32::NAN;
+
+use crate::decoders::*;
+use crate::decoders::tiff::*;
+use crate::decoders::basics::*;
 
 #[derive(Debug, Clone)]
 pub struct DcsDecoder<'a> {
@@ -22,7 +23,7 @@ impl<'a> DcsDecoder<'a> {
 
 impl<'a> Decoder for DcsDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
-    let camera = try!(self.rawloader.check_supported(&self.tiff));
+    let camera = self.rawloader.check_supported(&self.tiff)?;
     let data = self.tiff.find_ifds_with_tag(Tag::StripOffsets);
     let raw = data.iter().find(|&&ifd| {
       ifd.find_entry(Tag::ImageWidth).unwrap().get_u32(0) > 1000

--- a/src/decoders/erf.rs
+++ b/src/decoders/erf.rs
@@ -1,7 +1,8 @@
-use decoders::*;
-use decoders::tiff::*;
-use decoders::basics::*;
 use std::f32::NAN;
+
+use crate::decoders::*;
+use crate::decoders::tiff::*;
+use crate::decoders::basics::*;
 
 #[derive(Debug, Clone)]
 pub struct ErfDecoder<'a> {
@@ -22,7 +23,7 @@ impl<'a> ErfDecoder<'a> {
 
 impl<'a> Decoder for ErfDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
-    let camera = try!(self.rawloader.check_supported(&self.tiff));
+    let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, Tag::CFAPattern);
     let width = fetch_tag!(raw, Tag::ImageWidth).get_usize(0);
     let height = fetch_tag!(raw, Tag::ImageLength).get_usize(0);
@@ -30,7 +31,7 @@ impl<'a> Decoder for ErfDecoder<'a> {
     let src = &self.buffer[offset..];
 
     let image = decode_12be_wcontrol(src, width, height, dummy);
-    ok_image(camera, width, height, try!(self.get_wb()), image)
+    ok_image(camera, width, height, self.get_wb()?, image)
   }
 }
 

--- a/src/decoders/iiq.rs
+++ b/src/decoders/iiq.rs
@@ -1,7 +1,8 @@
-use decoders::*;
-use decoders::tiff::*;
-use decoders::basics::*;
 use std::f32::NAN;
+
+use crate::decoders::*;
+use crate::decoders::tiff::*;
+use crate::decoders::basics::*;
 
 #[derive(Debug, Clone)]
 pub struct IiqDecoder<'a> {
@@ -22,7 +23,7 @@ impl<'a> IiqDecoder<'a> {
 
 impl<'a> Decoder for IiqDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
-    let camera = try!(self.rawloader.check_supported(&self.tiff));
+    let camera = self.rawloader.check_supported(&self.tiff)?;
 
     let off = LEu32(self.buffer, 16) as usize + 8;
     let entries = LEu32(self.buffer, off);
@@ -55,7 +56,7 @@ impl<'a> Decoder for IiqDecoder<'a> {
 
     let image = Self::decode_compressed(self.buffer, data_offset, strip_offset, width, height, dummy);
 
-    ok_image_with_blacklevels(camera, width, height, try!(self.get_wb(wb_offset)), [black, black, black, black], image)
+    ok_image_with_blacklevels(camera, width, height, self.get_wb(wb_offset)?, [black, black, black, black], image)
   }
 }
 

--- a/src/decoders/image.rs
+++ b/src/decoders/image.rs
@@ -1,5 +1,5 @@
-use decoders::*;
-use decoders::cfa::*;
+use crate::decoders::*;
+use crate::decoders::cfa::*;
 
 /// All the data needed to process this raw image, including the image data itself as well
 /// as all the needed metadata

--- a/src/decoders/kdc.rs
+++ b/src/decoders/kdc.rs
@@ -1,7 +1,8 @@
-use decoders::*;
-use decoders::tiff::*;
-use decoders::basics::*;
 use std::f32::NAN;
+
+use crate::decoders::*;
+use crate::decoders::tiff::*;
+use crate::decoders::basics::*;
 
 #[derive(Debug, Clone)]
 pub struct KdcDecoder<'a> {
@@ -22,7 +23,7 @@ impl<'a> KdcDecoder<'a> {
 
 impl<'a> Decoder for KdcDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
-    let camera = try!(self.rawloader.check_supported(&self.tiff));
+    let camera = self.rawloader.check_supported(&self.tiff)?;
 
     if camera.model == "Kodak DC120 ZOOM Digital Camera" {
       let width = 848;
@@ -54,7 +55,7 @@ impl<'a> Decoder for KdcDecoder<'a> {
     let src = &self.buffer[off..];
     let image = decode_12be(src, width, height, dummy);
 
-    ok_image(camera, width, height, try!(self.get_wb()), image)
+    ok_image(camera, width, height, self.get_wb()?, image)
   }
 }
 

--- a/src/decoders/ljpeg/huffman.rs
+++ b/src/decoders/ljpeg/huffman.rs
@@ -35,7 +35,7 @@
 */
 
 use std::fmt;
-use decoders::basics::*;
+use crate::decoders::basics::*;
 
 const BIG_TABLE_BITS: u32 = 13;
 
@@ -106,7 +106,7 @@ impl HuffTable {
       initialized: false,
     };
     // Always use big table, haven't found a situation where it doesn't help
-    try!(tbl.initialize(true));
+    tbl.initialize(true)?;
     Ok(tbl)
   }
 
@@ -262,7 +262,7 @@ impl HuffTable {
   }
 
   // Taken from Figure F.16: extract next coded symbol from input stream
-  pub fn huff_decode(&self, pump: &mut BitPump) -> Result<i32,String> {
+  pub fn huff_decode(&self, pump: &mut dyn BitPump) -> Result<i32,String> {
     //First attempt to do complete decode, by using the first 14 bits
     if self.use_bigtable {
       let code = pump.peek_bits(BIG_TABLE_BITS) as usize;
@@ -273,12 +273,12 @@ impl HuffTable {
       }
     }
 
-    let len = try!(self.huff_len(pump));
+    let len = self.huff_len(pump)?;
     let diff = self.huff_diff(pump, len);
     Ok(diff)
   }
 
-  pub fn huff_len(&self, pump: &mut BitPump) -> Result<u32,String> {
+  pub fn huff_len(&self, pump: &mut dyn BitPump) -> Result<u32,String> {
     let mut code = pump.peek_bits(8) as usize;
     let val = self.numbits[code as usize] as u32;
     let len = val & 15;
@@ -305,7 +305,7 @@ impl HuffTable {
     }
   }
 
-  pub fn huff_diff(&self, pump: &mut BitPump, len: u32) -> i32 {
+  pub fn huff_diff(&self, pump: &mut dyn BitPump, len: u32) -> i32 {
     match len {
       0 => 0,
       16 => {

--- a/src/decoders/mef.rs
+++ b/src/decoders/mef.rs
@@ -1,6 +1,6 @@
-use decoders::*;
-use decoders::tiff::*;
-use decoders::basics::*;
+use crate::decoders::*;
+use crate::decoders::tiff::*;
+use crate::decoders::basics::*;
 use std::f32::NAN;
 
 #[derive(Debug, Clone)]
@@ -22,7 +22,7 @@ impl<'a> MefDecoder<'a> {
 
 impl<'a> Decoder for MefDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
-    let camera = try!(self.rawloader.check_supported(&self.tiff));
+    let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, Tag::CFAPattern);
     let width = fetch_tag!(raw, Tag::ImageWidth).get_usize(0);
     let height = fetch_tag!(raw, Tag::ImageLength).get_usize(0);

--- a/src/decoders/mrw.rs
+++ b/src/decoders/mrw.rs
@@ -1,7 +1,8 @@
-use decoders::*;
-use decoders::tiff::*;
-use decoders::basics::*;
 use std::f32;
+
+use crate::decoders::*;
+use crate::decoders::tiff::*;
+use crate::decoders::basics::*;
 
 pub fn is_mrw(buf: &[u8]) -> bool {
   BEu32(buf,0) == 0x004D524D
@@ -70,7 +71,7 @@ impl<'a> MrwDecoder<'a> {
 
 impl<'a> Decoder for MrwDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
-    let camera = try!(self.rawloader.check_supported(&self.tiff));
+    let camera = self.rawloader.check_supported(&self.tiff)?;
     let src = &self.buffer[self.data_offset..];
 
     let buffer = if self.packed {

--- a/src/decoders/nkd.rs
+++ b/src/decoders/nkd.rs
@@ -1,5 +1,5 @@
-use decoders::*;
-use decoders::basics::*;
+use crate::decoders::*;
+use crate::decoders::basics::*;
 use std::f32::NAN;
 
 #[derive(Debug, Clone)]

--- a/src/decoders/nrw.rs
+++ b/src/decoders/nrw.rs
@@ -1,7 +1,8 @@
-use decoders::*;
-use decoders::tiff::*;
-use decoders::basics::*;
 use std::f32::NAN;
+
+use crate::decoders::*;
+use crate::decoders::tiff::*;
+use crate::decoders::basics::*;
 
 #[derive(Debug, Clone)]
 pub struct NrwDecoder<'a> {
@@ -22,7 +23,7 @@ impl<'a> NrwDecoder<'a> {
 
 impl<'a> Decoder for NrwDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
-    let camera = try!(self.rawloader.check_supported(&self.tiff));
+    let camera = self.rawloader.check_supported(&self.tiff)?;
     let data = self.tiff.find_ifds_with_tag(Tag::CFAPattern);
     let raw = data.iter().find(|&&ifd| {
       ifd.find_entry(Tag::ImageWidth).unwrap().get_u32(0) > 1000

--- a/src/decoders/orf.rs
+++ b/src/decoders/orf.rs
@@ -1,8 +1,9 @@
-use decoders::*;
-use decoders::tiff::*;
-use decoders::basics::*;
 use std::f32::NAN;
 use std::cmp;
+
+use crate::decoders::*;
+use crate::decoders::tiff::*;
+use crate::decoders::basics::*;
 
 #[derive(Debug, Clone)]
 pub struct OrfDecoder<'a> {
@@ -23,7 +24,7 @@ impl<'a> OrfDecoder<'a> {
 
 impl<'a> Decoder for OrfDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
-    let camera = try!(self.rawloader.check_supported(&self.tiff));
+    let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, Tag::StripOffsets);
     let width = fetch_tag!(raw, Tag::ImageWidth).get_usize(0);
     let height = fetch_tag!(raw, Tag::ImageLength).get_usize(0);
@@ -35,7 +36,7 @@ impl<'a> Decoder for OrfDecoder<'a> {
     }
 
     let camera = if width >= camera.highres_width {
-      try!(self.rawloader.check_supported_with_mode(&self.tiff, "highres"))
+      self.rawloader.check_supported_with_mode(&self.tiff, "highres")?
     } else {
       camera
     };
@@ -61,8 +62,8 @@ impl<'a> Decoder for OrfDecoder<'a> {
     };
 
     match self.get_blacks() {
-      Ok(val) => ok_image_with_blacklevels(camera, width, height, try!(self.get_wb()), val, image),
-      Err(_)  => ok_image(camera, width, height, try!(self.get_wb()), image),
+      Ok(val) => ok_image_with_blacklevels(camera, width, height, self.get_wb()?, val, image),
+      Err(_)  => ok_image(camera, width, height, self.get_wb()?, image),
     }
   }
 }

--- a/src/decoders/packed.rs
+++ b/src/decoders/packed.rs
@@ -1,4 +1,4 @@
-use decoders::basics::*;
+use crate::decoders::basics::*;
 
 pub fn decode_8bit_wtable(buf: &[u8], tbl: &LookupTable, width: usize, height: usize, dummy: bool) -> Vec<u16> {
   decode_threaded(width, height, dummy,&(|out: &mut [u16], row| {

--- a/src/decoders/pumps.rs
+++ b/src/decoders/pumps.rs
@@ -1,4 +1,4 @@
-use decoders::basics::*;
+use crate::decoders::basics::*;
 
 #[derive(Debug, Copy, Clone)]
 pub struct BitPumpLSB<'a> {

--- a/src/decoders/raf.rs
+++ b/src/decoders/raf.rs
@@ -1,7 +1,8 @@
-use decoders::*;
-use decoders::tiff::*;
-use decoders::basics::*;
 use std::f32::NAN;
+
+use crate::decoders::*;
+use crate::decoders::tiff::*;
+use crate::decoders::basics::*;
 
 #[derive(Debug, Clone)]
 pub struct RafDecoder<'a> {
@@ -22,7 +23,7 @@ impl<'a> RafDecoder<'a> {
 
 impl<'a> Decoder for RafDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
-    let camera = try!(self.rawloader.check_supported(&self.tiff));
+    let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, Tag::RafOffsets);
     let (width,height) = if raw.has_entry(Tag::RafImageWidth) {
       (fetch_tag!(raw, Tag::RafImageWidth).get_usize(0),
@@ -73,7 +74,7 @@ impl<'a> Decoder for RafDecoder<'a> {
         width: width,
         height: height,
         cpp: 1,
-        wb_coeffs: try!(self.get_wb()),
+        wb_coeffs: self.get_wb()?,
         data: RawImageData::Integer(image),
         blacklevels: camera.blacklevels,
         whitelevels: camera.whitelevels,
@@ -84,7 +85,7 @@ impl<'a> Decoder for RafDecoder<'a> {
         orientation: camera.orientation,
       })
     } else {
-      ok_image(camera, width, height, try!(self.get_wb()), image)
+      ok_image(camera, width, height, self.get_wb()?, image)
     }
   }
 }

--- a/src/decoders/rw2.rs
+++ b/src/decoders/rw2.rs
@@ -1,7 +1,8 @@
-use decoders::*;
-use decoders::tiff::*;
-use decoders::basics::*;
 use std::f32::NAN;
+
+use crate::decoders::*;
+use crate::decoders::tiff::*;
+use crate::decoders::basics::*;
 
 #[derive(Debug, Clone)]
 pub struct Rw2Decoder<'a> {
@@ -62,9 +63,9 @@ impl<'a> Decoder for Rw2Decoder<'a> {
         "16:9"
       }
     };
-    let camera = try!(self.rawloader.check_supported_with_mode(&self.tiff, mode));
+    let camera = self.rawloader.check_supported_with_mode(&self.tiff, mode)?;
 
-    ok_image(camera, width, height, try!(self.get_wb()), image)
+    ok_image(camera, width, height, self.get_wb()?, image)
   }
 }
 

--- a/src/decoders/srw.rs
+++ b/src/decoders/srw.rs
@@ -1,8 +1,9 @@
-use decoders::*;
-use decoders::tiff::*;
-use decoders::basics::*;
 use std::f32::NAN;
 use std::cmp;
+
+use crate::decoders::*;
+use crate::decoders::tiff::*;
+use crate::decoders::basics::*;
 
 #[derive(Debug, Clone)]
 pub struct SrwDecoder<'a> {
@@ -23,7 +24,7 @@ impl<'a> SrwDecoder<'a> {
 
 impl<'a> Decoder for SrwDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
-    let camera = try!(self.rawloader.check_supported(&self.tiff));
+    let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, Tag::StripOffsets);
     let width = fetch_tag!(raw, Tag::ImageWidth).get_usize(0);
     let height = fetch_tag!(raw, Tag::ImageLength).get_usize(0);
@@ -67,7 +68,7 @@ impl<'a> Decoder for SrwDecoder<'a> {
       x => return Err(format!("SRW: Don't know how to handle compression {}", x).to_string()),
     };
 
-    ok_image(camera, width, height, try!(self.get_wb()), image)
+    ok_image(camera, width, height, self.get_wb()?, image)
   }
 }
 

--- a/src/decoders/tiff.rs
+++ b/src/decoders/tiff.rs
@@ -1,7 +1,9 @@
-use std::collections::HashMap;
-use decoders::basics::*;
-use std::str;
+use enum_primitive::{enum_from_primitive, enum_from_primitive_impl, enum_from_primitive_impl_ty};
 use num::FromPrimitive;
+use std::collections::HashMap;
+use std::str;
+
+use crate::decoders::basics::*;
 
 enum_from_primitive! {
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -173,7 +175,7 @@ impl<'a> TiffIFD<'a> {
     };
     let mut nextifd = endian.ru32(buf, offset+4) as usize;
     for _ in 0..100 { // Never read more than 100 IFDs
-      let ifd = try!(TiffIFD::new(&buf[offset..], nextifd, 0, offset, 0, endian));
+      let ifd = TiffIFD::new(&buf[offset..], nextifd, 0, offset, 0, endian)?;
       nextifd = ifd.nextifd;
       subifds.push(ifd);
       if nextifd == 0 {
@@ -254,7 +256,7 @@ impl<'a> TiffIFD<'a> {
         off += 4;
       }
 
-      let mut mainifd = try!(TiffIFD::new(buf, offset+off, base_offset, 0, depth, endian));
+      let mut mainifd = TiffIFD::new(buf, offset+off, base_offset, 0, depth, endian)?;
 
       if off == 12 {
         // Parse the Olympus ImgProc section if it exists
@@ -262,7 +264,7 @@ impl<'a> TiffIFD<'a> {
           entry.get_usize(0)
         } else { 0 };
         if ioff != 0 {
-          let iprocifd = try!(TiffIFD::new(&buf[offset+ioff..], 0, ioff, 0, depth, endian));
+          let iprocifd = TiffIFD::new(&buf[offset+ioff..], 0, ioff, 0, depth, endian)?;
           mainifd.subifds.push(iprocifd);
         }
       }

--- a/src/decoders/unwrapped.rs
+++ b/src/decoders/unwrapped.rs
@@ -1,5 +1,5 @@
-use decoders::*;
-use decoders::basics::*;
+use crate::decoders::*;
+use crate::decoders::basics::*;
 
 pub fn decode_unwrapped(buffer: &Buffer) -> Result<RawImageData,String> {
   let decoder = LEu16(&buffer.buf, 0);
@@ -131,8 +131,8 @@ pub fn decode_unwrapped(buffer: &Buffer) -> Result<RawImageData,String> {
 
 fn decode_ljpeg(src: &[u8], width: usize, height: usize, dng_bug: bool, csfix: bool) -> Result<RawImageData,String> {
   let mut out = vec![0u16; width*height];
-  let decompressor = try!(ljpeg::LjpegDecompressor::new_full(src, dng_bug, csfix));
-  try!(decompressor.decode(&mut out, 0, width, width, height, false));
+  let decompressor = ljpeg::LjpegDecompressor::new_full(src, dng_bug, csfix)?;
+  decompressor.decode(&mut out, 0, width, width, height, false)?;
   Ok(RawImageData::Integer(out))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@
 //! use std::io::prelude::*;
 //! use std::io::BufWriter;
 //!
-//! extern crate rawloader;
-//!
 //! fn main() {
 //!   let args: Vec<_> = env::args().collect();
 //!   if args.len() != 2 {
@@ -47,11 +45,7 @@
   unused_qualifications
 )]
 
-#[macro_use] extern crate enum_primitive;
-extern crate num;
-#[macro_use] extern crate lazy_static;
-#[macro_use] extern crate serde_derive;
-extern crate itertools;
+use lazy_static::lazy_static;
 
 mod decoders;
 pub use decoders::RawImage;
@@ -120,7 +114,7 @@ pub fn decode_file<P: AsRef<Path>>(path: P) -> Result<RawImage,RawLoaderError> {
 ///   Err(e) => ... some appropriate action when the file is unreadable ...
 /// };
 /// ```
-pub fn decode(reader: &mut Read) -> Result<RawImage,RawLoaderError> {
+pub fn decode(reader: &mut dyn Read) -> Result<RawImage,RawLoaderError> {
   LOADER.decode(reader, false).map_err(|err| RawLoaderError::new(err))
 }
 
@@ -135,12 +129,12 @@ pub fn force_initialization() {
 // Used for fuzzing targets that just want to test the actual decoders instead of the full formats
 // with all their TIFF and other crazyness
 #[doc(hidden)]
-pub fn decode_unwrapped(reader: &mut Read) -> Result<RawImageData,RawLoaderError> {
+pub fn decode_unwrapped(reader: &mut dyn Read) -> Result<RawImageData,RawLoaderError> {
   LOADER.decode_unwrapped(reader).map_err(|err| RawLoaderError::new(err))
 }
 
 // Used for fuzzing everything but the decoders themselves
 #[doc(hidden)]
-pub fn decode_dummy(reader: &mut Read) -> Result<RawImage,RawLoaderError> {
+pub fn decode_dummy(reader: &mut dyn Read) -> Result<RawImage,RawLoaderError> {
   LOADER.decode(reader, true).map_err(|err| RawLoaderError::new(err))
 }


### PR DESCRIPTION
This addresses https://github.com/pedrocr/imagepipe/issues/5 for rawloader.

* Changed edition to 2018
* Removed all `extern crate` and `#[macro_use]`.
* Replaced `try!()` with `?`
* Fixed crate local imports to be prefixed with `crate::`. I also moved them below the other imports in each file (my personal taste).