### PR TITLE
Replace enum_primitive with enumn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ build = "data/cameras/join.rs"
 [dependencies]
 toml = "0.5"
 time = "0.2"
-enum_primitive = "0.1"
+enumn = "0.1"
 num = "0.2"
 lazy_static = "1"
 byteorder = "1"

--- a/src/decoders/ciff.rs
+++ b/src/decoders/ciff.rs
@@ -1,10 +1,8 @@
-use enum_primitive::{enum_from_primitive, enum_from_primitive_impl, enum_from_primitive_impl_ty};
 use std::collections::HashMap;
 
 use crate::decoders::basics::*;
 use crate::decoders::Buffer;
 
-enum_from_primitive! {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum CiffTag {
   Null         = 0x0000,
@@ -19,7 +17,6 @@ pub enum CiffTag {
   RawData      = 0x2005,
   SubIFD       = 0x300a,
   Exif         = 0x300b,
-}
 }
 
 fn ct (tag: CiffTag) -> u16 {

--- a/src/decoders/tiff.rs
+++ b/src/decoders/tiff.rs
@@ -1,12 +1,11 @@
-use enum_primitive::{enum_from_primitive, enum_from_primitive_impl, enum_from_primitive_impl_ty};
 use num::FromPrimitive;
 use std::collections::HashMap;
 use std::str;
 
 use crate::decoders::basics::*;
 
-enum_from_primitive! {
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, enumn::N)]
+#[repr(u16)]
 pub enum Tag {
   PanaWidth        = 0x0002,
   PanaLength       = 0x0003,
@@ -95,7 +94,6 @@ pub enum Tag {
   KdcLength        = 0xFD01,
   KdcOffset        = 0xFD04,
   KdcIFD           = 0xFE00,
-}
 }
 
                           // 0-1-2-3-4-5-6-7-8-9-10-11-12-13
@@ -202,7 +200,7 @@ impl<'a> TiffIFD<'a> {
     }
     for i in 0..num {
       let entry_offset: usize = offset + 2 + (i as usize)*12;
-      if Tag::from_u16(e.ru16(buf, entry_offset)).is_none() {
+      if Tag::n(e.ru16(buf, entry_offset)).is_none() {
         // Skip entries we don't know about to speedup decoding
         continue;
       }


### PR DESCRIPTION
This replaces my [original attempt](https://github.com/pedrocr/rawloader/pull/22) at replacing enum_primitive with a maintained crate by instead using [enumn](https://crates.io/crates/enumn), a much smaller and simpler crate made by the same author of popular crates like [syn](https://crates.io/crates/syn).

Here's the relevant enumn's generated code:

```rust
impl Tag {
    pub fn n(value: (u16)) -> Option<Self> {
        struct discriminant;
        impl discriminant {
            const PanaWidth: (u16) = Tag::PanaWidth as (u16);
            const PanaLength: (u16) = Tag::PanaLength as (u16);
            const NefWB0: (u16) = Tag::NefWB0 as (u16);
            const PanaWBsR: (u16) = Tag::PanaWBsR as (u16);
            const PanaWBsB: (u16) = Tag::PanaWBsB as (u16);
            const NrwWB: (u16) = Tag::NrwWB as (u16);
            const NefSerial: (u16) = Tag::NefSerial as (u16);
            const PanaWBs2R: (u16) = Tag::PanaWBs2R as (u16);
            const PanaWBs2G: (u16) = Tag::PanaWBs2G as (u16);
            const PanaWBs2B: (u16) = Tag::PanaWBs2B as (u16);
            const Cr2PowerShotWB: (u16) = Tag::Cr2PowerShotWB as (u16);
            const NewSubFileType: (u16) = Tag::NewSubFileType as (u16);
            const Cr2OldOffset: (u16) = Tag::Cr2OldOffset as (u16);
            const NefMeta1: (u16) = Tag::NefMeta1 as (u16);
            const NefMeta2: (u16) = Tag::NefMeta2 as (u16);
            const NefWB1: (u16) = Tag::NefWB1 as (u16);
            const Cr2OldWB: (u16) = Tag::Cr2OldWB as (u16);
            const NefKey: (u16) = Tag::NefKey as (u16);
            const ImageWidth: (u16) = Tag::ImageWidth as (u16);
            const ImageLength: (u16) = Tag::ImageLength as (u16);
            const BitsPerSample: (u16) = Tag::BitsPerSample as (u16);
            const Compression: (u16) = Tag::Compression as (u16);
            const PhotometricInt: (u16) = Tag::PhotometricInt as (u16);
            const Make: (u16) = Tag::Make as (u16);
            const Model: (u16) = Tag::Model as (u16);
            const StripOffsets: (u16) = Tag::StripOffsets as (u16);
            const Orientation: (u16) = Tag::Orientation as (u16);
            const SamplesPerPixel: (u16) = Tag::SamplesPerPixel as (u16);
            const StripByteCounts: (u16) = Tag::StripByteCounts as (u16);
            const PanaOffsets: (u16) = Tag::PanaOffsets as (u16);
            const GrayResponse: (u16) = Tag::GrayResponse as (u16);
            const Software: (u16) = Tag::Software as (u16);
            const TileWidth: (u16) = Tag::TileWidth as (u16);
            const TileLength: (u16) = Tag::TileLength as (u16);
            const TileOffsets: (u16) = Tag::TileOffsets as (u16);
            const SubIFDs: (u16) = Tag::SubIFDs as (u16);
            const PefBlackLevels: (u16) = Tag::PefBlackLevels as (u16);
            const PefWB: (u16) = Tag::PefWB as (u16);
            const PefHuffman: (u16) = Tag::PefHuffman as (u16);
            const Xmp: (u16) = Tag::Xmp as (u16);
            const DcrWB: (u16) = Tag::DcrWB as (u16);
            const OrfBlackLevels: (u16) = Tag::OrfBlackLevels as (u16);
            const DcrLinearization: (u16) = Tag::DcrLinearization as (u16);
            const EpsonWB: (u16) = Tag::EpsonWB as (u16);
            const KodakWB: (u16) = Tag::KodakWB as (u16);
            const OlympusRedMul: (u16) = Tag::OlympusRedMul as (u16);
            const OlympusBlueMul: (u16) = Tag::OlympusBlueMul as (u16);
            const OlympusImgProc: (u16) = Tag::OlympusImgProc as (u16);
            const RafOldWB: (u16) = Tag::RafOldWB as (u16);
            const Cr2ColorData: (u16) = Tag::Cr2ColorData as (u16);
            const SonyCurve: (u16) = Tag::SonyCurve as (u16);
            const SonyOffset: (u16) = Tag::SonyOffset as (u16);
            const SonyLength: (u16) = Tag::SonyLength as (u16);
            const SonyKey: (u16) = Tag::SonyKey as (u16);
            const SonyGRBG: (u16) = Tag::SonyGRBG as (u16);
            const SonyRGGB: (u16) = Tag::SonyRGGB as (u16);
            const CFAPattern: (u16) = Tag::CFAPattern as (u16);
            const KodakIFD: (u16) = Tag::KodakIFD as (u16);
            const LeafMetadata: (u16) = Tag::LeafMetadata as (u16);
            const ExifIFDPointer: (u16) = Tag::ExifIFDPointer as (u16);
            const Makernote: (u16) = Tag::Makernote as (u16);
            const SrwSensorAreas: (u16) = Tag::SrwSensorAreas as (u16);
            const SrwRGGBLevels: (u16) = Tag::SrwRGGBLevels as (u16);
            const SrwRGGBBlacks: (u16) = Tag::SrwRGGBBlacks as (u16);
            const Cr2Id: (u16) = Tag::Cr2Id as (u16);
            const DNGVersion: (u16) = Tag::DNGVersion as (u16);
            const Linearization: (u16) = Tag::Linearization as (u16);
            const BlackLevels: (u16) = Tag::BlackLevels as (u16);
            const WhiteLevel: (u16) = Tag::WhiteLevel as (u16);
            const ColorMatrix1: (u16) = Tag::ColorMatrix1 as (u16);
            const ColorMatrix2: (u16) = Tag::ColorMatrix2 as (u16);
            const AsShotNeutral: (u16) = Tag::AsShotNeutral as (u16);
            const DNGPrivateArea: (u16) = Tag::DNGPrivateArea as (u16);
            const Cr2StripeWidths: (u16) = Tag::Cr2StripeWidths as (u16);
            const ActiveArea: (u16) = Tag::ActiveArea as (u16);
            const MaskedAreas: (u16) = Tag::MaskedAreas as (u16);
            const RafRawSubIFD: (u16) = Tag::RafRawSubIFD as (u16);
            const RafImageWidth: (u16) = Tag::RafImageWidth as (u16);
            const RafImageLength: (u16) = Tag::RafImageLength as (u16);
            const RafBitsPerSample: (u16) = Tag::RafBitsPerSample as (u16);
            const RafOffsets: (u16) = Tag::RafOffsets as (u16);
            const RafWBGRB: (u16) = Tag::RafWBGRB as (u16);
            const KdcWB: (u16) = Tag::KdcWB as (u16);
            const KdcWidth: (u16) = Tag::KdcWidth as (u16);
            const KdcLength: (u16) = Tag::KdcLength as (u16);
            const KdcOffset: (u16) = Tag::KdcOffset as (u16);
            const KdcIFD: (u16) = Tag::KdcIFD as (u16);
        }
        match value {
            discriminant::PanaWidth => Some(Tag::PanaWidth),
            discriminant::PanaLength => Some(Tag::PanaLength),
            discriminant::NefWB0 => Some(Tag::NefWB0),
            discriminant::PanaWBsR => Some(Tag::PanaWBsR),
            discriminant::PanaWBsB => Some(Tag::PanaWBsB),
            discriminant::NrwWB => Some(Tag::NrwWB),
            discriminant::NefSerial => Some(Tag::NefSerial),
            discriminant::PanaWBs2R => Some(Tag::PanaWBs2R),
            discriminant::PanaWBs2G => Some(Tag::PanaWBs2G),
            discriminant::PanaWBs2B => Some(Tag::PanaWBs2B),
            discriminant::Cr2PowerShotWB => Some(Tag::Cr2PowerShotWB),
            discriminant::NewSubFileType => Some(Tag::NewSubFileType),
            discriminant::Cr2OldOffset => Some(Tag::Cr2OldOffset),
            discriminant::NefMeta1 => Some(Tag::NefMeta1),
            discriminant::NefMeta2 => Some(Tag::NefMeta2),
            discriminant::NefWB1 => Some(Tag::NefWB1),
            discriminant::Cr2OldWB => Some(Tag::Cr2OldWB),
            discriminant::NefKey => Some(Tag::NefKey),
            discriminant::ImageWidth => Some(Tag::ImageWidth),
            discriminant::ImageLength => Some(Tag::ImageLength),
            discriminant::BitsPerSample => Some(Tag::BitsPerSample),
            discriminant::Compression => Some(Tag::Compression),
            discriminant::PhotometricInt => Some(Tag::PhotometricInt),
            discriminant::Make => Some(Tag::Make),
            discriminant::Model => Some(Tag::Model),
            discriminant::StripOffsets => Some(Tag::StripOffsets),
            discriminant::Orientation => Some(Tag::Orientation),
            discriminant::SamplesPerPixel => Some(Tag::SamplesPerPixel),
            discriminant::StripByteCounts => Some(Tag::StripByteCounts),
            discriminant::PanaOffsets => Some(Tag::PanaOffsets),
            discriminant::GrayResponse => Some(Tag::GrayResponse),
            discriminant::Software => Some(Tag::Software),
            discriminant::TileWidth => Some(Tag::TileWidth),
            discriminant::TileLength => Some(Tag::TileLength),
            discriminant::TileOffsets => Some(Tag::TileOffsets),
            discriminant::SubIFDs => Some(Tag::SubIFDs),
            discriminant::PefBlackLevels => Some(Tag::PefBlackLevels),
            discriminant::PefWB => Some(Tag::PefWB),
            discriminant::PefHuffman => Some(Tag::PefHuffman),
            discriminant::Xmp => Some(Tag::Xmp),
            discriminant::DcrWB => Some(Tag::DcrWB),
            discriminant::OrfBlackLevels => Some(Tag::OrfBlackLevels),
            discriminant::DcrLinearization => Some(Tag::DcrLinearization),
            discriminant::EpsonWB => Some(Tag::EpsonWB),
            discriminant::KodakWB => Some(Tag::KodakWB),
            discriminant::OlympusRedMul => Some(Tag::OlympusRedMul),
            discriminant::OlympusBlueMul => Some(Tag::OlympusBlueMul),
            discriminant::OlympusImgProc => Some(Tag::OlympusImgProc),
            discriminant::RafOldWB => Some(Tag::RafOldWB),
            discriminant::Cr2ColorData => Some(Tag::Cr2ColorData),
            discriminant::SonyCurve => Some(Tag::SonyCurve),
            discriminant::SonyOffset => Some(Tag::SonyOffset),
            discriminant::SonyLength => Some(Tag::SonyLength),
            discriminant::SonyKey => Some(Tag::SonyKey),
            discriminant::SonyGRBG => Some(Tag::SonyGRBG),
            discriminant::SonyRGGB => Some(Tag::SonyRGGB),
            discriminant::CFAPattern => Some(Tag::CFAPattern),
            discriminant::KodakIFD => Some(Tag::KodakIFD),
            discriminant::LeafMetadata => Some(Tag::LeafMetadata),
            discriminant::ExifIFDPointer => Some(Tag::ExifIFDPointer),
            discriminant::Makernote => Some(Tag::Makernote),
            discriminant::SrwSensorAreas => Some(Tag::SrwSensorAreas),
            discriminant::SrwRGGBLevels => Some(Tag::SrwRGGBLevels),
            discriminant::SrwRGGBBlacks => Some(Tag::SrwRGGBBlacks),
            discriminant::Cr2Id => Some(Tag::Cr2Id),
            discriminant::DNGVersion => Some(Tag::DNGVersion),
            discriminant::Linearization => Some(Tag::Linearization),
            discriminant::BlackLevels => Some(Tag::BlackLevels),
            discriminant::WhiteLevel => Some(Tag::WhiteLevel),
            discriminant::ColorMatrix1 => Some(Tag::ColorMatrix1),
            discriminant::ColorMatrix2 => Some(Tag::ColorMatrix2),
            discriminant::AsShotNeutral => Some(Tag::AsShotNeutral),
            discriminant::DNGPrivateArea => Some(Tag::DNGPrivateArea),
            discriminant::Cr2StripeWidths => Some(Tag::Cr2StripeWidths),
            discriminant::ActiveArea => Some(Tag::ActiveArea),
            discriminant::MaskedAreas => Some(Tag::MaskedAreas),
            discriminant::RafRawSubIFD => Some(Tag::RafRawSubIFD),
            discriminant::RafImageWidth => Some(Tag::RafImageWidth),
            discriminant::RafImageLength => Some(Tag::RafImageLength),
            discriminant::RafBitsPerSample => Some(Tag::RafBitsPerSample),
            discriminant::RafOffsets => Some(Tag::RafOffsets),
            discriminant::RafWBGRB => Some(Tag::RafWBGRB),
            discriminant::KdcWB => Some(Tag::KdcWB),
            discriminant::KdcWidth => Some(Tag::KdcWidth),
            discriminant::KdcLength => Some(Tag::KdcLength),
            discriminant::KdcOffset => Some(Tag::KdcOffset),
            discriminant::KdcIFD => Some(Tag::KdcIFD),
            _ => None,
        }
    }
}
```