### PR TITLE
Fixed deprecated time measurement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ build = "data/cameras/join.rs"
 
 [dependencies]
 toml = "0.5"
-time = "0.2"
 enum_primitive = "0.1"
 num = "0.2"
 lazy_static = "1"

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs::File;
 use std::error::Error;
+use std::time::Instant;
 
 fn usage() {
   println!("benchmark <file>");
@@ -31,7 +32,7 @@ fn main() {
     Err(e) => {error(&e); return},
   };
   let rawloader = rawloader::RawLoader::new();
-  let from_time = time::PrimitiveDateTime::now();
+  let from_time = Instant::now();
   {
     for _ in 0..ITERATIONS {
       let decoder = match rawloader.get_decoder(&buffer) {
@@ -44,8 +45,8 @@ fn main() {
       }
     }
   }
-  let to_time = time::PrimitiveDateTime::now();
+  let duration = from_time.elapsed();
 
-  let avgtime = (((to_time-from_time).whole_nanoseconds() as u64)/ITERATIONS/1000) as f64 / 1000.0;
+  let avgtime = ((duration.as_nanos() as u64)/ITERATIONS/1000) as f64 / 1000.0;
   println!("Average decode time: {} ms ({} iterations)", avgtime, ITERATIONS);
 }


### PR DESCRIPTION
Hi Pedro,

same changes like yesterday from `imagepipe`. Replacing time measurement using `time` crate with `std::time`.

Best regards,
Maximilian