### PR TITLE
SRW: Keep scale for lossy compressed v3 images

### DIFF
--- a/src/decoders/srw.rs
+++ b/src/decoders/srw.rs
@@ -282,7 +282,7 @@ impl<'a> SrwDecoder<'a> {
             pump.get_bits(12) as i32
           }
         } else {
-          0
+          scale // Keep value from previous iteration
         };
 
         // First we figure out which reference pixels mode we're in


### PR DESCRIPTION
While integrating srw support into dnglab, I stumbled across this little bug. The Samsung NX500 (see raw samples at raw.pixls.us) produces 12 and 14 bit images with lossy or lossless compression. For lossy, the srw3 scale parameter is used to rescale the pixels. The scale is recalculated every 64 pixels. Resetting the scale to zero in other cases leads to invalid images.

Output of an image decoded with invalid scale values:

![grafik](https://user-images.githubusercontent.com/509535/167005137-274a0ed8-3e51-448c-990a-4ddc0b6711d9.png)


Fell free to modify this PR for your needs.

Just FYI: I've played around the srw3 decoder and I'm not sure if it is properly implemented. The diff and out values are all clamped to u16. If the calculation is done entirely with i32 and after full decompression everything is clamped to u16, the checksum for the output is different. And again different when only one row (in the for-height loop) is keept as i32 and then clamped and copied into the out buffer. So three methods, three different outputs. I don't see any visible difference, I just wonder what's the correct method is. I can't find a source at opensource.samsung.com.