### PR TITLE
fix: RawLoader unused qualification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub use decoders::cfa::CFA;
 #[doc(hidden)] pub use decoders::RawLoader;
 
 lazy_static! {
-  static ref LOADER: RawLoader = decoders::RawLoader::new();
+  static ref LOADER: RawLoader = RawLoader::new();
 }
 
 use std::path::Path;


### PR DESCRIPTION
Fix compile issue.  Running `cargo build` on the project has a `unused_qualifications` error since the RawLoader is already imported:

```
error: unnecessary qualification
  --> src/lib.rs:59:34
   |
59 |   static ref LOADER: RawLoader = decoders::RawLoader::new();
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> src/lib.rs:45:3
   |
45 |   unused_qualifications
   |   ^^^^^^^^^^^^^^^^^^^^^
help: remove the unnecessary path segments
   |
59 -   static ref LOADER: RawLoader = decoders::RawLoader::new();
59 +   static ref LOADER: RawLoader = RawLoader::new();
   |
```

# Info
```
> rustc --version
rustc 1.87.0 (17067e9ac 2025-05-09)
 
> cargo --version
cargo 1.87.0 (99624be96 2025-05-06)
```

