### PR TITLE
fix: bounds-check all byte-reading helpers to prevent panics on malformed input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ build = "data/cameras/join.rs"
 toml = "0.5"
 enumn = "0.1"
 lazy_static = "1"
-byteorder = "1"
 rayon = "1"
 
 [build-dependencies]

--- a/src/decoders/ari.rs
+++ b/src/decoders/ari.rs
@@ -24,9 +24,9 @@ impl<'a> AriDecoder<'a> {
 
 impl<'a> Decoder for AriDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
-    let offset = LEu32(self.buffer, 8) as usize;
-    let width = LEu32(self.buffer, 20) as usize;
-    let height = LEu32(self.buffer, 24) as usize;
+    let offset = LEu32(self.buffer, 8).unwrap_or(0) as usize;
+    let width = LEu32(self.buffer, 20).unwrap_or(0) as usize;
+    let height = LEu32(self.buffer, 24).unwrap_or(0) as usize;
     let model = String::from_utf8_lossy(&self.buffer[668..]).split_terminator("\0").next().unwrap_or("").to_string();
     let camera = self.rawloader.check_supported_with_everything("ARRI", &model, "")?;
     let src = &self.buffer[offset..];
@@ -39,6 +39,6 @@ impl<'a> Decoder for AriDecoder<'a> {
 
 impl<'a> AriDecoder<'a> {
   fn get_wb(&self) -> Result<[f32;4], String> {
-    Ok([LEf32(self.buffer, 100), LEf32(self.buffer, 104), LEf32(self.buffer, 108), NAN])
+    Ok([LEf32(self.buffer, 100).unwrap_or(0.0), LEf32(self.buffer, 104).unwrap_or(0.0), LEf32(self.buffer, 108).unwrap_or(0.0), NAN])
   }
 }

--- a/src/decoders/arw.rs
+++ b/src/decoders/arw.rs
@@ -114,12 +114,12 @@ impl<'a> ArwDecoder<'a> {
     let mut wb_coeffs: [f32;4] = [0.0, 0.0, 0.0, NAN];
     // At most we read 20 bytes from currpos so check we don't step outside that
     while currpos+20 < buf.len() {
-      let tag: u32 = BEu32(buf,currpos);
-      let len: usize = LEu32(buf,currpos+4) as usize;
+      let tag: u32 = BEu32(buf,currpos).unwrap_or(0);
+      let len: usize = LEu32(buf,currpos+4).unwrap_or(0) as usize;
       if tag == 0x574247 { // WBG
-        wb_coeffs[0] = LEu16(buf, currpos+12) as f32;
-        wb_coeffs[1] = LEu16(buf, currpos+14) as f32;
-        wb_coeffs[2] = LEu16(buf, currpos+18) as f32;
+        wb_coeffs[0] = LEu16(buf, currpos+12).unwrap_or(0) as f32;
+        wb_coeffs[1] = LEu16(buf, currpos+14).unwrap_or(0) as f32;
+        wb_coeffs[2] = LEu16(buf, currpos+18).unwrap_or(0) as f32;
         break;
       }
       currpos += len+8;
@@ -150,9 +150,9 @@ impl<'a> ArwDecoder<'a> {
 
       // Replicate the dcraw contortions to get the "decryption" key
       let offset = (self.buffer[key_off] as usize)*4;
-      let first_key = BEu32(self.buffer, key_off+offset);
+      let first_key = BEu32(self.buffer, key_off+offset).unwrap_or(0);
       let head = ArwDecoder::sony_decrypt(self.buffer, head_off, 40, first_key);
-      let second_key = LEu32(&head, 22);
+      let second_key = LEu32(&head, 22).unwrap_or(0);
 
       // "Decrypt" the whole image buffer
       let image_data = ArwDecoder::sony_decrypt(self.buffer, off, len, second_key);
@@ -290,7 +290,7 @@ impl<'a> ArwDecoder<'a> {
     for i in 0..(length/4+1) {
       let p = i + 127;
       pad[p & 127] = pad[(p+1) & 127] ^ pad[(p+1+64) & 127];
-      let output = LEu32(buf, offset+i*4) ^ pad[p & 127];
+      let output = LEu32(buf, offset+i*4).unwrap_or(0) ^ pad[p & 127];
       out.push(((output >>  0) & 0xff) as u8);
       out.push(((output >>  8) & 0xff) as u8);
       out.push(((output >> 16) & 0xff) as u8);

--- a/src/decoders/basics.rs
+++ b/src/decoders/basics.rs
@@ -1,4 +1,3 @@
-use byteorder::{BigEndian, LittleEndian, ByteOrder};
 use rayon::prelude::*;
 
 pub use crate::decoders::packed::*;
@@ -22,7 +21,7 @@ pub struct Endian {
 }
 
 impl Endian {
-  pub fn ri32(&self, buf: &[u8], pos: usize) -> i32 {
+  pub fn ri32(&self, buf: &[u8], pos: usize) -> Option<i32> {
     if self.big {
       BEi32(buf,pos)
     } else {
@@ -30,7 +29,7 @@ impl Endian {
     }
   }
 
-  pub fn ru32(&self, buf: &[u8], pos: usize) -> u32 {
+  pub fn ru32(&self, buf: &[u8], pos: usize) -> Option<u32> {
     if self.big {
       BEu32(buf,pos)
     } else {
@@ -38,7 +37,7 @@ impl Endian {
     }
   }
 
-  pub fn ru16(&self, buf: &[u8], pos: usize) -> u16 {
+  pub fn ru16(&self, buf: &[u8], pos: usize) -> Option<u16> {
     if self.big {
       BEu16(buf,pos)
     } else {
@@ -52,32 +51,39 @@ impl Endian {
 pub static BIG_ENDIAN: Endian = Endian{big: true};
 pub static LITTLE_ENDIAN: Endian = Endian{big: false};
 
-#[allow(non_snake_case)] #[inline] pub fn BEi32(buf: &[u8], pos: usize) -> i32 {
-  BigEndian::read_i32(&buf[pos..pos+4])
+#[allow(non_snake_case)] #[inline] pub fn BEi32(buf: &[u8], pos: usize) -> Option<i32> {
+  let s = buf.get(pos..pos+4)?;
+  Some(i32::from_be_bytes([s[0], s[1], s[2], s[3]]))
 }
 
-#[allow(non_snake_case)] #[inline] pub fn LEi32(buf: &[u8], pos: usize) -> i32 {
-  LittleEndian::read_i32(&buf[pos..pos+4])
+#[allow(non_snake_case)] #[inline] pub fn LEi32(buf: &[u8], pos: usize) -> Option<i32> {
+  let s = buf.get(pos..pos+4)?;
+  Some(i32::from_le_bytes([s[0], s[1], s[2], s[3]]))
 }
 
-#[allow(non_snake_case)] #[inline] pub fn BEu32(buf: &[u8], pos: usize) -> u32 {
-  BigEndian::read_u32(&buf[pos..pos+4])
+#[allow(non_snake_case)] #[inline] pub fn BEu32(buf: &[u8], pos: usize) -> Option<u32> {
+  let s = buf.get(pos..pos+4)?;
+  Some(u32::from_be_bytes([s[0], s[1], s[2], s[3]]))
 }
 
-#[allow(non_snake_case)] #[inline] pub fn LEu32(buf: &[u8], pos: usize) -> u32 {
-  LittleEndian::read_u32(&buf[pos..pos+4])
+#[allow(non_snake_case)] #[inline] pub fn LEu32(buf: &[u8], pos: usize) -> Option<u32> {
+  let s = buf.get(pos..pos+4)?;
+  Some(u32::from_le_bytes([s[0], s[1], s[2], s[3]]))
 }
 
-#[allow(non_snake_case)] #[inline] pub fn LEf32(buf: &[u8], pos: usize) -> f32 {
-  LittleEndian::read_f32(&buf[pos..pos+4])
+#[allow(non_snake_case)] #[inline] pub fn LEf32(buf: &[u8], pos: usize) -> Option<f32> {
+  let s = buf.get(pos..pos+4)?;
+  Some(f32::from_le_bytes([s[0], s[1], s[2], s[3]]))
 }
 
-#[allow(non_snake_case)] #[inline] pub fn BEu16(buf: &[u8], pos: usize) -> u16 {
-  BigEndian::read_u16(&buf[pos..pos+2])
+#[allow(non_snake_case)] #[inline] pub fn BEu16(buf: &[u8], pos: usize) -> Option<u16> {
+  let s = buf.get(pos..pos+2)?;
+  Some(u16::from_be_bytes([s[0], s[1]]))
 }
 
-#[allow(non_snake_case)] #[inline] pub fn LEu16(buf: &[u8], pos: usize) -> u16 {
-  LittleEndian::read_u16(&buf[pos..pos+2])
+#[allow(non_snake_case)] #[inline] pub fn LEu16(buf: &[u8], pos: usize) -> Option<u16> {
+  let s = buf.get(pos..pos+2)?;
+  Some(u16::from_le_bytes([s[0], s[1]]))
 }
 
 pub fn decode_threaded<F>(width: usize, height: usize, dummy: bool, closure: &F) -> Vec<u16>

--- a/src/decoders/ciff.rs
+++ b/src/decoders/ciff.rs
@@ -40,21 +40,21 @@ pub struct CiffIFD<'a> {
 }
 
 pub fn is_ciff(buf: &[u8]) -> bool {
-  buf[6..14] == b"HEAPCCDR"[..]
+  buf.get(6..14) == Some(&b"HEAPCCDR"[..])
 }
 
 impl<'a> CiffIFD<'a> {
   pub fn new_file(buf: &'a Buffer) -> Result<CiffIFD<'a>,String> {
     let data = &buf.buf;
-    CiffIFD::new(data, LEu32(data,2) as usize, buf.size, 1)
+    CiffIFD::new(data, LEu32(data,2).unwrap_or(0) as usize, buf.size, 1)
   }
 
   pub fn new(buf: &'a[u8], start: usize, end: usize, depth: u32) -> Result<CiffIFD<'a>, String> {
     let mut entries = HashMap::new();
     let mut subifds = Vec::new();
 
-    let valuedata_size = LEu32(buf, end-4) as usize;
-    let dircount = LEu16(buf, start+valuedata_size) as usize;
+    let valuedata_size = LEu32(buf, end-4).unwrap_or(0) as usize;
+    let dircount = LEu16(buf, start+valuedata_size).unwrap_or(0) as usize;
 
     for i in 0..dircount {
       let entry_offset: usize = start+valuedata_size+2+i*10;
@@ -95,14 +95,14 @@ impl<'a> CiffIFD<'a> {
 
 impl<'a> CiffEntry<'a> {
   pub fn new(buf: &'a[u8], value_data: usize, offset: usize) -> Result<CiffEntry<'a>, String> {
-    let p = LEu16(buf, offset);
+    let p = LEu16(buf, offset).unwrap_or(0);
     let tag = p & 0x3fff;
     let datalocation = (p & 0xc000) as usize;
     let typ = p & 0x3800;
 
     let (bytesize, data_offset) = match datalocation {
       // Data is offset in value_data
-      0x0000 => (LEu32(buf, offset+2) as usize, LEu32(buf, offset+6) as usize + value_data),
+      0x0000 => (LEu32(buf, offset+2).unwrap_or(0) as usize, LEu32(buf, offset+6).unwrap_or(0) as usize + value_data),
       // Data is stored directly in entry
       0x4000 => (8, offset+2),
       val => return Err(format!("CIFF: Don't know about data location {:x}", val).to_string()),
@@ -140,13 +140,13 @@ impl<'a> CiffEntry<'a> {
   pub fn get_u32(&self, idx: usize) -> u32 {
     match self.typ {
       0x0000 | 0x8000                       => self.data[idx] as u32,
-      0x1000                                => LEu16(self.data, idx*2) as u32,
-      0x1800 | 0x2000 | 0x2800 | 0x3000     => LEu32(self.data, idx*4),
+      0x1000                                => LEu16(self.data, idx*2).unwrap_or(0) as u32,
+      0x1800 | 0x2000 | 0x2800 | 0x3000     => LEu32(self.data, idx*4).unwrap_or(0),
       _ => panic!("Trying to read typ {} for a u32", self.typ),
     }
   }
 
   pub fn get_usize(&self, idx: usize) -> usize { self.get_u32(idx) as usize }
   pub fn get_f32(&self, idx: usize) -> f32 { self.get_u32(idx) as f32 }
-  pub fn get_force_u16(&self, idx: usize) -> u16 { LEu16(self.data, idx*2) }
+  pub fn get_force_u16(&self, idx: usize) -> u16 { LEu16(self.data, idx*2).unwrap_or(0) }
 }

--- a/src/decoders/dcr.rs
+++ b/src/decoders/dcr.rs
@@ -51,9 +51,9 @@ impl<'a> DcrDecoder<'a> {
     let dcrwb = fetch_tag!(self.tiff, Tag::DcrWB);
     if dcrwb.count() >= 46 {
       let levels = dcrwb.get_data();
-      Ok([2048.0 / BEu16(levels,40) as f32,
-          2048.0 / BEu16(levels,42) as f32,
-          2048.0 / BEu16(levels,44) as f32,
+      Ok([2048.0 / BEu16(levels,40).unwrap_or(1) as f32,
+          2048.0 / BEu16(levels,42).unwrap_or(1) as f32,
+          2048.0 / BEu16(levels,44).unwrap_or(1) as f32,
           NAN])
     } else {
       Ok([NAN,NAN,NAN,NAN])

--- a/src/decoders/erf.rs
+++ b/src/decoders/erf.rs
@@ -41,8 +41,8 @@ impl<'a> ErfDecoder<'a> {
     if levels.count() != 256 {
       Err("ERF: Levels count is off".to_string())
     } else {
-      let r = BEu16(levels.get_data(), 48) as f32;
-      let b = BEu16(levels.get_data(), 50) as f32;
+      let r = BEu16(levels.get_data(), 48).unwrap_or(0) as f32;
+      let b = BEu16(levels.get_data(), 50).unwrap_or(0) as f32;
       Ok([r * 508.0 * 1.078 / 65536.0, 1.0, b * 382.0 * 1.173 / 65536.0, NAN])
     }
   }

--- a/src/decoders/iiq.rs
+++ b/src/decoders/iiq.rs
@@ -25,8 +25,8 @@ impl<'a> Decoder for IiqDecoder<'a> {
   fn image(&self, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
 
-    let off = LEu32(self.buffer, 16) as usize + 8;
-    let entries = LEu32(self.buffer, off);
+    let off = LEu32(self.buffer, 16).unwrap_or(0) as usize + 8;
+    let entries = LEu32(self.buffer, off).unwrap_or(0);
     let mut pos = 8;
 
     let mut wb_offset: usize = 0;
@@ -36,8 +36,8 @@ impl<'a> Decoder for IiqDecoder<'a> {
     let mut strip_offset: usize = 0;
     let mut black: u16 = 0;
     for _ in 0..entries {
-      let tag = LEu32(self.buffer, off+pos);
-      let data = LEu32(self.buffer, off+pos+12) as usize;
+      let tag = LEu32(self.buffer, off+pos).unwrap_or(0);
+      let data = LEu32(self.buffer, off+pos+12).unwrap_or(0) as usize;
       pos += 16;
       match tag {
         0x107 => wb_offset = data+8,
@@ -62,16 +62,16 @@ impl<'a> Decoder for IiqDecoder<'a> {
 
 impl<'a> IiqDecoder<'a> {
   fn get_wb(&self, wb_offset: usize) -> Result<[f32;4], String> {
-    Ok([LEf32(self.buffer, wb_offset),
-        LEf32(self.buffer, wb_offset+4),
-        LEf32(self.buffer, wb_offset+8), NAN])
+    Ok([LEf32(self.buffer, wb_offset).unwrap_or(0.0),
+        LEf32(self.buffer, wb_offset+4).unwrap_or(0.0),
+        LEf32(self.buffer, wb_offset+8).unwrap_or(0.0), NAN])
   }
 
   pub(crate) fn decode_compressed(buffer: &[u8], data_offset: usize, strip_offset: usize, width: usize, height: usize, dummy: bool) -> Vec<u16>{
     let lens: [u32; 10] = [8,7,6,9,11,10,5,12,14,13];
 
     decode_threaded(width, height, dummy, &(|out: &mut [u16], row| {
-      let offset = data_offset + LEu32(buffer, strip_offset+row*4) as usize;
+      let offset = data_offset + LEu32(buffer, strip_offset+row*4).unwrap_or(0) as usize;
       let mut pump = BitPumpMSB32::new(&buffer[offset..]);
       let mut pred = [0 as u32; 2];
       let mut len = [0 as u32; 2];

--- a/src/decoders/kdc.rs
+++ b/src/decoders/kdc.rs
@@ -74,8 +74,8 @@ impl<'a> KdcDecoder<'a> {
         if levels.count() != 734 && levels.count() != 1502 {
           Err("KDC: Levels count is off".to_string())
         } else {
-          let r = BEu16(levels.get_data(), 148) as f32;
-          let b = BEu16(levels.get_data(), 150) as f32;
+          let r = BEu16(levels.get_data(), 148).unwrap_or(0) as f32;
+          let b = BEu16(levels.get_data(), 150).unwrap_or(0) as f32;
           Ok([r / 256.0, 1.0, b / 256.0, NAN])
         }
       },

--- a/src/decoders/mod.rs
+++ b/src/decoders/mod.rs
@@ -429,7 +429,7 @@ impl RawLoader {
     }
 
     if x3f::is_x3f(buffer) {
-      let dec = Box::new(x3f::X3fDecoder::new(buf, &self));
+      let dec = Box::new(x3f::X3fDecoder::new(buf, &self)?);
       return Ok(dec as Box<dyn Decoder>);
     }
 

--- a/src/decoders/mrw.rs
+++ b/src/decoders/mrw.rs
@@ -5,7 +5,7 @@ use crate::decoders::tiff::*;
 use crate::decoders::basics::*;
 
 pub fn is_mrw(buf: &[u8]) -> bool {
-  BEu32(buf,0) == 0x004D524D
+  BEu32(buf,0) == Some(0x004D524D)
 }
 
 #[derive(Debug, Clone)]
@@ -22,7 +22,7 @@ pub struct MrwDecoder<'a> {
 
 impl<'a> MrwDecoder<'a> {
   pub fn new(buf: &'a [u8], rawloader: &'a RawLoader) -> MrwDecoder<'a> {
-    let data_offset: usize = (BEu32(buf, 4) + 8) as usize;
+    let data_offset: usize = (BEu32(buf, 4).unwrap_or(0) + 8) as usize;
     let mut raw_height: usize = 0;
     let mut raw_width: usize = 0;
     let mut packed = false;
@@ -32,18 +32,18 @@ impl<'a> MrwDecoder<'a> {
     let mut currpos: usize = 8;
     // At most we read 20 bytes from currpos so check we don't step outside that
     while currpos+20 < data_offset {
-      let tag: u32 = BEu32(buf,currpos);
-      let len: u32 = BEu32(buf,currpos+4);
-      
+      let tag: u32 = BEu32(buf,currpos).unwrap_or(0);
+      let len: u32 = BEu32(buf,currpos+4).unwrap_or(0);
+
       match tag {
         0x505244 => { // PRD
-          raw_height = BEu16(buf,currpos+16) as usize;
-          raw_width = BEu16(buf,currpos+18) as usize;
+          raw_height = BEu16(buf,currpos+16).unwrap_or(0) as usize;
+          raw_width = BEu16(buf,currpos+18).unwrap_or(0) as usize;
           packed = buf[currpos+24] == 12;
         }
         0x574247 => { // WBG
           for i in 0..4 {
-            wb_vals[i] = BEu16(buf, currpos+12+i*2);
+            wb_vals[i] = BEu16(buf, currpos+12+i*2).unwrap_or(0);
           }
         }
         0x545457 => { // TTW

--- a/src/decoders/nef.rs
+++ b/src/decoders/nef.rs
@@ -201,8 +201,8 @@ impl<'a> NefDecoder<'a> {
           }
 
           let off = if version == 0x204 { 6 } else { 14 };
-          Ok([BEu16(&buf, off) as f32, BEu16(&buf, off+2) as f32,
-              BEu16(&buf, off+6) as f32, NAN])
+          Ok([BEu16(&buf, off).unwrap_or(0) as f32, BEu16(&buf, off+2).unwrap_or(0) as f32,
+              BEu16(&buf, off+6).unwrap_or(0) as f32, NAN])
         },
         x => Err(format!("NEF: Don't know about WB version 0x{:x}", x).to_string()),
       }
@@ -278,7 +278,7 @@ impl<'a> NefDecoder<'a> {
         points[i] = ((points[i-i%step] as usize * (step - i % step) +
                      points[i-i%step+step] as usize * (i%step)) / step) as u16;
       }
-      split = endian.ru16(meta, 562) as usize;
+      split = endian.ru16(meta, 562).unwrap_or(0) as usize;
     } else if v0 != 70 && csize <= 0x4001 {
       for i in 0..csize {
         points[i] = stream.get_u16();
@@ -339,7 +339,7 @@ impl<'a> NefDecoder<'a> {
 
     decode_threaded(width*3, height, dummy, &(|out: &mut [u16], row| {
       let inb = &src[row*width*3..];
-      let mut random = BEu32(inb, 0);
+      let mut random = BEu32(inb, 0).unwrap_or(0);
       for (o, i) in out.chunks_exact_mut(6).zip(inb.chunks_exact(6)) {
         let g1: u16 = i[0] as u16;
         let g2: u16 = i[1] as u16;

--- a/src/decoders/nrw.rs
+++ b/src/decoders/nrw.rs
@@ -63,12 +63,12 @@ impl<'a> NrwDecoder<'a> {
           56
         };
 
-        Ok([(LEu32(data, offset) << 2) as f32,
-            (LEu32(data, offset+4) + LEu32(data, offset+8)) as f32,
-            (LEu32(data, offset+12) << 2) as f32,
+        Ok([(LEu32(data, offset).unwrap_or(0) << 2) as f32,
+            (LEu32(data, offset+4).unwrap_or(0) + LEu32(data, offset+8).unwrap_or(0)) as f32,
+            (LEu32(data, offset+12).unwrap_or(0) << 2) as f32,
             NAN])
       } else {
-        Ok([BEu16(data,1248) as f32, 256.0, BEu16(data,1250) as f32, NAN])
+        Ok([BEu16(data,1248).unwrap_or(0) as f32, 256.0, BEu16(data,1250).unwrap_or(0) as f32, NAN])
       }
     } else {
       Err("NRW: Don't know how to fetch WB".to_string())

--- a/src/decoders/packed.rs
+++ b/src/decoders/packed.rs
@@ -3,7 +3,7 @@ use crate::decoders::basics::*;
 pub fn decode_8bit_wtable(buf: &[u8], tbl: &LookupTable, width: usize, height: usize, dummy: bool) -> Vec<u16> {
   decode_threaded(width, height, dummy,&(|out: &mut [u16], row| {
     let inb = &buf[(row*width)..];
-    let mut random = LEu32(inb, 0);
+    let mut random = LEu32(inb, 0).unwrap_or(0);
 
     for (o, i) in out.chunks_exact_mut(1).zip(inb.chunks_exact(1)) {
       o[0] = tbl.dither(i[0] as u16, &mut random);
@@ -239,7 +239,7 @@ pub fn decode_12le_unpacked(buf: &[u8], width: usize, height: usize, dummy: bool
     let inb = &buf[(row*width*2)..];
 
     for (i, bytes) in (0..width).zip(inb.chunks_exact(2)) {
-      out[i] = LEu16(bytes, 0) & 0x0fff;
+      out[i] = LEu16(bytes, 0).unwrap_or(0) & 0x0fff;
     }
   }))
 }
@@ -249,7 +249,7 @@ pub fn decode_12be_unpacked(buf: &[u8], width: usize, height: usize, dummy: bool
     let inb = &buf[(row*width*2)..];
 
     for (i, bytes) in (0..width).zip(inb.chunks_exact(2)) {
-      out[i] = BEu16(bytes, 0) & 0x0fff;
+      out[i] = BEu16(bytes, 0).unwrap_or(0) & 0x0fff;
     }
   }))
 }
@@ -259,7 +259,7 @@ pub fn decode_12be_unpacked_left_aligned(buf: &[u8], width: usize, height: usize
     let inb = &buf[(row*width*2)..];
 
     for (i, bytes) in (0..width).zip(inb.chunks_exact(2)) {
-      out[i] = BEu16(bytes, 0) >> 4;
+      out[i] = BEu16(bytes, 0).unwrap_or(0) >> 4;
     }
   }))
 }
@@ -269,7 +269,7 @@ pub fn decode_12le_unpacked_left_aligned(buf: &[u8], width: usize, height: usize
     let inb = &buf[(row*width*2)..];
 
     for (i, bytes) in (0..width).zip(inb.chunks_exact(2)) {
-      out[i] = LEu16(bytes, 0) >> 4;
+      out[i] = LEu16(bytes, 0).unwrap_or(0) >> 4;
     }
   }))
 }
@@ -279,7 +279,7 @@ pub fn decode_14le_unpacked(buf: &[u8], width: usize, height: usize, dummy: bool
     let inb = &buf[(row*width*2)..];
 
     for (i, bytes) in (0..width).zip(inb.chunks_exact(2)) {
-      out[i] = LEu16(bytes, 0) & 0x3fff;
+      out[i] = LEu16(bytes, 0).unwrap_or(0) & 0x3fff;
     }
   }))
 }
@@ -289,7 +289,7 @@ pub fn decode_14be_unpacked(buf: &[u8], width: usize, height: usize, dummy: bool
     let inb = &buf[(row*width*2)..];
 
     for (i, bytes) in (0..width).zip(inb.chunks_exact(2)) {
-      out[i] = BEu16(bytes, 0) & 0x3fff;
+      out[i] = BEu16(bytes, 0).unwrap_or(0) & 0x3fff;
     }
   }))
 }
@@ -299,7 +299,7 @@ pub fn decode_16le(buf: &[u8], width: usize, height: usize, dummy: bool) -> Vec<
     let inb = &buf[(row*width*2)..];
 
     for (i, bytes) in (0..width).zip(inb.chunks_exact(2)) {
-      out[i] = LEu16(bytes, 0);
+      out[i] = LEu16(bytes, 0).unwrap_or(0);
     }
   }))
 }
@@ -309,7 +309,7 @@ pub fn decode_16le_skiplines(buf: &[u8], width: usize, height: usize, dummy: boo
     let inb = &buf[(row*width*4)..];
 
     for (i, bytes) in (0..width).zip(inb.chunks_exact(2)) {
-      out[i] = LEu16(bytes, 0);
+      out[i] = LEu16(bytes, 0).unwrap_or(0);
     }
   }))
 }
@@ -319,7 +319,7 @@ pub fn decode_16be(buf: &[u8], width: usize, height: usize, dummy: bool) -> Vec<
     let inb = &buf[(row*width*2)..];
 
     for (i, bytes) in (0..width).zip(inb.chunks_exact(2)) {
-      out[i] = BEu16(bytes, 0);
+      out[i] = BEu16(bytes, 0).unwrap_or(0);
     }
   }))
 }

--- a/src/decoders/pumps.rs
+++ b/src/decoders/pumps.rs
@@ -121,7 +121,7 @@ impl<'a> BitPump for BitPumpLSB<'a> {
   #[inline(always)]
   fn peek_bits(&mut self, num: u32) -> u32 {
     if num > self.nbits {
-      let inbits: u64 = LEu32(self.buffer, self.pos) as u64;
+      let inbits: u64 = LEu32(self.buffer, self.pos).unwrap_or(0) as u64;
       self.bits = ((inbits << 32) | (self.bits << (32-self.nbits))) >> (32-self.nbits);
       self.pos += 4;
       self.nbits += 32;
@@ -140,7 +140,7 @@ impl<'a> BitPump for BitPumpMSB<'a> {
   #[inline(always)]
   fn peek_bits(&mut self, num: u32) -> u32 {
     if num > self.nbits {
-      let inbits: u64 = BEu32(self.buffer, self.pos) as u64;
+      let inbits: u64 = BEu32(self.buffer, self.pos).unwrap_or(0) as u64;
       self.bits = (self.bits << 32) | inbits;
       self.pos += 4;
       self.nbits += 32;
@@ -159,7 +159,7 @@ impl<'a> BitPump for BitPumpMSB32<'a> {
   #[inline(always)]
   fn peek_bits(&mut self, num: u32) -> u32 {
     if num > self.nbits {
-      let inbits: u64 = LEu32(self.buffer, self.pos) as u64;
+      let inbits: u64 = LEu32(self.buffer, self.pos).unwrap_or(0) as u64;
       self.bits = (self.bits << 32) | inbits;
       self.pos += 4;
       self.nbits += 32;
@@ -183,7 +183,7 @@ impl<'a> BitPump for BitPumpJPEG<'a> {
          self.buffer[self.pos+1] != 0xff &&
          self.buffer[self.pos+2] != 0xff &&
          self.buffer[self.pos+3] != 0xff {
-        let inbits: u64 = BEu32(self.buffer, self.pos) as u64;
+        let inbits: u64 = BEu32(self.buffer, self.pos).unwrap_or(0) as u64;
         self.bits = (self.bits << 32) | inbits;
         self.pos += 4;
         self.nbits += 32;
@@ -260,7 +260,7 @@ impl<'a> ByteStream<'a> {
   }
 
   #[inline(always)]
-  pub fn peek_u16(&self) -> u16 { self.endian.ru16(self.buffer, self.pos) }
+  pub fn peek_u16(&self) -> u16 { self.endian.ru16(self.buffer, self.pos).unwrap_or(0) }
   #[inline(always)]
   pub fn get_u16(&mut self) -> u16 {
     let val = self.peek_u16();

--- a/src/decoders/rw2.rs
+++ b/src/decoders/rw2.rs
@@ -156,7 +156,7 @@ impl<'a> BitPump for BitPumpPanasonic<'a> {
     if self.split {
       byte = (byte + 0x4000 - 0x2008) % 0x4000;
     }
-    let bits = LEu16(self.buffer, byte as usize + self.pos - 0x4000) as u32;
+    let bits = LEu16(self.buffer, byte as usize + self.pos - 0x4000).unwrap_or(0) as u32;
     (bits >> ((self.nbits-num) & 7)) & (0x0ffffffffu32 >> (32-num))
   }
 

--- a/src/decoders/srw.rs
+++ b/src/decoders/srw.rs
@@ -78,7 +78,7 @@ impl<'a> SrwDecoder<'a> {
 
     for row in 0..height {
       let mut len: [u32; 4] = [if row < 2 {7} else {4}; 4];
-      let loffset = LEu32(loffsets, row*4) as usize;
+      let loffset = LEu32(loffsets, row*4).unwrap_or(0) as usize;
       let mut pump = BitPumpMSB32::new(&buf[loffset..]);
 
       let img      = width*row;

--- a/src/decoders/tiff.rs
+++ b/src/decoders/tiff.rs
@@ -124,13 +124,14 @@ pub struct TiffIFD<'a> {
 
 impl<'a> TiffIFD<'a> {
   pub fn new_file(buf: &'a[u8]) -> Result<TiffIFD<'a>, String> {
-    if buf[0..8] == b"FUJIFILM"[..] {
-      let ifd1 = TiffIFD::new_root(buf, (BEu32(buf, 84)+12) as usize)?;
+    if buf.get(0..8) == Some(&b"FUJIFILM"[..]) {
+      let off84 = BEu32(buf, 84).ok_or("FUJI: buffer too short for header offset at 84")?;
+      let ifd1 = TiffIFD::new_root(buf, (off84+12) as usize)?;
       let endian = ifd1.get_endian();
       let mut subifds = vec![ifd1];
       let mut entries = HashMap::new();
 
-      let ioffset = BEu32(buf, 100) as usize;
+      let ioffset = BEu32(buf, 100).ok_or("FUJI: buffer too short for IFD offset at 100")? as usize;
       match TiffIFD::new_root(buf, ioffset) {
         Ok(val) => {subifds.push(val);}
         Err(_) => {
@@ -145,7 +146,7 @@ impl<'a> TiffIFD<'a> {
           });
         },
       }
-      match TiffIFD::new_fuji(buf, BEu32(buf, 92) as usize) {
+      match TiffIFD::new_fuji(buf, BEu32(buf, 92).ok_or("FUJI: buffer too short for Fuji IFD offset at 92")? as usize) {
         Ok(val) => subifds.push(val),
         Err(_) => {}
       }
@@ -165,12 +166,12 @@ impl<'a> TiffIFD<'a> {
   pub fn new_root(buf: &'a[u8], offset: usize) -> Result<TiffIFD<'a>, String> {
     let mut subifds = Vec::new();
 
-    let endian = match LEu16(buf, offset) {
+    let endian = match LEu16(buf, offset).ok_or("TIFF: buffer too short for endian marker")? {
       0x4949 => LITTLE_ENDIAN,
       0x4d4d => BIG_ENDIAN,
       x => {return Err(format!("TIFF: don't know marker 0x{:x}", x).to_string())},
     };
-    let mut nextifd = endian.ru32(buf, offset+4) as usize;
+    let mut nextifd = endian.ru32(buf, offset+4).ok_or("TIFF: buffer too short for IFD offset")? as usize;
     for _ in 0..100 { // Never read more than 100 IFDs
       let ifd = TiffIFD::new(&buf[offset..], nextifd, 0, offset, 0, endian)?;
       nextifd = ifd.nextifd;
@@ -193,17 +194,27 @@ impl<'a> TiffIFD<'a> {
     let mut entries = HashMap::new();
     let mut subifds = Vec::new();
 
-    let num = e.ru16(buf, offset); // Directory entries in this IFD
+    let num = e.ru16(buf, offset).ok_or("TIFF: buffer too short for IFD entry count")?; // Directory entries in this IFD
     if num > 4000 {
       return Err(format!("too many entries in IFD ({})", num).to_string())
     }
+    // Validate that the buffer can hold all IFD entries plus the next-IFD pointer
+    let ifd_end = offset.checked_add(2 + (num as usize) * 12 + 4)
+      .ok_or("TIFF: IFD size overflow")?;
+    if ifd_end > buf.len() {
+      return Err(format!("TIFF: IFD with {} entries requires {} bytes, but only {} available",
+        num, ifd_end - offset, buf.len() - offset).to_string())
+    }
     for i in 0..num {
       let entry_offset: usize = offset + 2 + (i as usize)*12;
-      if Tag::n(e.ru16(buf, entry_offset)).is_none() {
+      if Tag::n(e.ru16(buf, entry_offset).unwrap_or(0)).is_none() {
         // Skip entries we don't know about to speedup decoding
         continue;
       }
-      let entry = TiffEntry::new(buf, entry_offset, base_offset, offset, e);
+      let entry = match TiffEntry::new(buf, entry_offset, base_offset, offset, e) {
+        Ok(e) => e,
+        Err(_) => continue, // Skip entries with out-of-bounds data
+      };
 
       if entry.tag == t(Tag::SubIFDs)
       || entry.tag == t(Tag::ExifIFDPointer)
@@ -235,7 +246,7 @@ impl<'a> TiffIFD<'a> {
     Ok(TiffIFD {
       entries: entries,
       subifds: subifds,
-      nextifd: e.ru32(buf, offset + (2+num*12) as usize) as usize,
+      nextifd: e.ru32(buf, offset + (2+num*12) as usize).unwrap_or(0) as usize,
       start_offset: start_offset,
       endian: e,
     })
@@ -243,13 +254,13 @@ impl<'a> TiffIFD<'a> {
 
   pub fn new_makernote(buf: &'a[u8], offset: usize, base_offset: usize, depth: u32, e: Endian) -> Result<TiffIFD<'a>, String> {
     let mut off = 0;
-    let data = &buf[offset..];
+    let data = buf.get(offset..).ok_or("TIFF: makernote offset out of bounds")?;
     let mut endian = e;
 
     // Olympus starts the makernote with their own name, sometimes truncated
-    if data[0..5] == b"OLYMP"[..] {
+    if data.get(0..5) == Some(&b"OLYMP"[..]) {
       off += 8;
-      if data[0..7] == b"OLYMPUS"[..] {
+      if data.get(0..7) == Some(&b"OLYMPUS"[..]) {
         off += 4;
       }
 
@@ -261,7 +272,8 @@ impl<'a> TiffIFD<'a> {
           entry.get_usize(0)
         } else { 0 };
         if ioff != 0 {
-          let iprocifd = TiffIFD::new(&buf[offset+ioff..], 0, ioff, 0, depth, endian)?;
+          let iprocifd = TiffIFD::new(buf.get(offset+ioff..).ok_or("TIFF: Olympus ImgProc offset out of bounds")?,
+            0, ioff, 0, depth, endian)?;
           mainifd.subifds.push(iprocifd);
         }
       }
@@ -270,33 +282,35 @@ impl<'a> TiffIFD<'a> {
     }
 
     // Epson starts the makernote with its own name
-    if data[0..5] == b"EPSON"[..] {
+    if data.get(0..5) == Some(&b"EPSON"[..]) {
       off += 8;
     }
 
     // Pentax makernote starts with AOC\0 - If it's there, skip it
-    if data[0..4] == b"AOC\0"[..] {
+    if data.get(0..4) == Some(&b"AOC\0"[..]) {
       off +=4;
     }
 
     // Pentax can also start with PENTAX and in that case uses different offsets
-    if data[0..6] == b"PENTAX"[..] {
+    if data.get(0..6) == Some(&b"PENTAX"[..]) {
       off += 8;
-      let endian = if data[off..off+2] == b"II"[..] {LITTLE_ENDIAN} else {BIG_ENDIAN};
-      return TiffIFD::new(&buf[offset..], 10, base_offset, 0, depth, endian)
+      let endian = if data.get(off..off+2) == Some(&b"II"[..]) {LITTLE_ENDIAN} else {BIG_ENDIAN};
+      return TiffIFD::new(buf.get(offset..).ok_or("TIFF: Pentax offset out of bounds")?,
+        10, base_offset, 0, depth, endian)
     }
 
-    if data[0..7] == b"Nikon\0\x02"[..] {
+    if data.get(0..7) == Some(&b"Nikon\0\x02"[..]) {
       off += 10;
-      let endian = if data[off..off+2] == b"II"[..] {LITTLE_ENDIAN} else {BIG_ENDIAN};
-      return TiffIFD::new(&buf[off+offset..], 8, base_offset, 0, depth, endian)
+      let endian = if data.get(off..off+2) == Some(&b"II"[..]) {LITTLE_ENDIAN} else {BIG_ENDIAN};
+      return TiffIFD::new(buf.get(off+offset..).ok_or("TIFF: Nikon offset out of bounds")?,
+        8, base_offset, 0, depth, endian)
     }
 
     // Some have MM or II to indicate endianness - read that
-    if data[off..off+2] == b"II"[..] {
+    if data.get(off..off+2) == Some(&b"II"[..]) {
       off +=2;
       endian = LITTLE_ENDIAN;
-    } if data[off..off+2] == b"MM"[..] {
+    } if data.get(off..off+2) == Some(&b"MM"[..]) {
       off +=2;
       endian = BIG_ENDIAN;
     }
@@ -306,34 +320,38 @@ impl<'a> TiffIFD<'a> {
 
   pub fn new_fuji(buf: &'a[u8], offset: usize) -> Result<TiffIFD<'a>, String> {
     let mut entries = HashMap::new();
-    let num = BEu32(buf, offset); // Directory entries in this IFD
+    let num = BEu32(buf, offset).ok_or("FUJI: buffer too short for directory count")?; // Directory entries in this IFD
     if num > 4000 {
       return Err(format!("too many entries in IFD ({})", num).to_string())
     }
     let mut off = offset+4;
     for _ in 0..num {
-      let tag = BEu16(buf, off);
-      let len = BEu16(buf, off+2);
+      let tag = match BEu16(buf, off) { Some(v) => v, None => break };
+      let len = match BEu16(buf, off+2) { Some(v) => v, None => break };
       if tag == t(Tag::ImageWidth) {
-        entries.insert(t(Tag::ImageWidth), TiffEntry {
-          tag: t(Tag::ImageWidth),
-          typ: 3, // Short
-          count: 2,
-          parent_offset: 0,
-          doffset: off+4,
-          data: &buf[off+4..off+8],
-          endian: BIG_ENDIAN,
-        });
+        if off + 8 <= buf.len() {
+          entries.insert(t(Tag::ImageWidth), TiffEntry {
+            tag: t(Tag::ImageWidth),
+            typ: 3, // Short
+            count: 2,
+            parent_offset: 0,
+            doffset: off+4,
+            data: &buf[off+4..off+8],
+            endian: BIG_ENDIAN,
+          });
+        }
       } else if tag == t(Tag::RafOldWB) {
-        entries.insert(t(Tag::RafOldWB), TiffEntry {
-          tag: t(Tag::RafOldWB),
-          typ: 3, // Short
-          count: 4,
-          parent_offset: 0,
-          doffset: off+4,
-          data: &buf[off+4..off+12],
-          endian: BIG_ENDIAN,
-        });
+        if off + 12 <= buf.len() {
+          entries.insert(t(Tag::RafOldWB), TiffEntry {
+            tag: t(Tag::RafOldWB),
+            typ: 3, // Short
+            count: 4,
+            parent_offset: 0,
+            doffset: off+4,
+            data: &buf[off+4..off+12],
+            endian: BIG_ENDIAN,
+          });
+        }
       }
       off += (len+4) as usize;
     }
@@ -394,32 +412,39 @@ impl<'a> TiffIFD<'a> {
 }
 
 impl<'a> TiffEntry<'a> {
-  pub fn new(buf: &'a[u8], offset: usize, base_offset: usize, parent_offset: usize, e: Endian) -> TiffEntry<'a> {
-    let tag = e.ru16(buf, offset);
-    let mut typ = e.ru16(buf, offset+2);
-    let count = e.ru32(buf, offset+4) as usize;
+  pub fn new(buf: &'a[u8], offset: usize, base_offset: usize, parent_offset: usize, e: Endian) -> Result<TiffEntry<'a>, String> {
+    let tag = e.ru16(buf, offset).unwrap_or(0);
+    let mut typ = e.ru16(buf, offset+2).unwrap_or(0);
+    let count = e.ru32(buf, offset+4).unwrap_or(0) as usize;
 
     // If we don't know the type assume byte data
     if typ == 0 || typ > 13 {
       typ = 1;
     }
 
-    let bytesize: usize = count << DATASHIFTS[typ as usize];
+    let bytesize: usize = count.checked_shl(DATASHIFTS[typ as usize] as u32)
+      .ok_or("TIFF: entry byte size overflow")?;
     let doffset: usize = if bytesize <= 4 {
       offset + 8
     } else {
-      (e.ru32(buf, offset+8) as usize) - base_offset
+      (e.ru32(buf, offset+8).unwrap_or(0) as usize).checked_sub(base_offset)
+        .ok_or("TIFF: entry data offset underflow")?
     };
 
-    TiffEntry {
+    let dend = doffset.checked_add(bytesize).ok_or("TIFF: entry data range overflow")?;
+    if dend > buf.len() {
+      return Err(format!("TIFF: entry data out of bounds ({} + {} > {})", doffset, bytesize, buf.len()))
+    }
+
+    Ok(TiffEntry {
       tag: tag,
       typ: typ,
       count: count,
       parent_offset: parent_offset,
       doffset: doffset,
-      data: &buf[doffset .. doffset+bytesize],
+      data: &buf[doffset .. dend],
       endian: e,
-    }
+    })
   }
 
   pub fn copy_with_new_data(&self, data: &'a[u8]) -> TiffEntry<'a> {
@@ -456,21 +481,21 @@ impl<'a> TiffEntry<'a> {
   pub fn get_usize(&self, idx: usize) -> usize { self.get_u32(idx) as usize }
 
   pub fn get_force_u32(&self, idx: usize) -> u32 {
-    self.endian.ru32(self.data, idx*4)
+    self.endian.ru32(self.data, idx*4).unwrap_or(0)
   }
 
   pub fn get_force_u16(&self, idx: usize) -> u16 {
-    self.endian.ru16(self.data, idx*2)
+    self.endian.ru16(self.data, idx*2).unwrap_or(0)
   }
 
   pub fn get_f32(&self, idx: usize) -> f32 {
     if self.typ == 5 { // Rational
-      let a = self.endian.ru32(self.data, idx*8) as f32;
-      let b = self.endian.ru32(self.data, idx*8+4) as f32;
+      let a = self.endian.ru32(self.data, idx*8).unwrap_or(0) as f32;
+      let b = self.endian.ru32(self.data, idx*8+4).unwrap_or(0) as f32;
       a / b
     } else if self.typ == 10 { // Signed Rational
-      let a = self.endian.ri32(self.data, idx*8) as f32;
-      let b = self.endian.ri32(self.data, idx*8+4) as f32;
+      let a = self.endian.ri32(self.data, idx*8).unwrap_or(0) as f32;
+      let b = self.endian.ri32(self.data, idx*8+4).unwrap_or(0) as f32;
       a / b
     } else {
       self.get_u32(idx) as f32

--- a/src/decoders/unwrapped.rs
+++ b/src/decoders/unwrapped.rs
@@ -2,9 +2,9 @@ use crate::decoders::*;
 use crate::decoders::basics::*;
 
 pub fn decode_unwrapped(buffer: &Buffer) -> Result<RawImageData,String> {
-  let decoder = LEu16(&buffer.buf, 0);
-  let width   = LEu16(&buffer.buf, 2) as usize;
-  let height  = LEu16(&buffer.buf, 4) as usize;
+  let decoder = LEu16(&buffer.buf, 0).unwrap_or(0);
+  let width   = LEu16(&buffer.buf, 2).unwrap_or(0) as usize;
+  let height  = LEu16(&buffer.buf, 4).unwrap_or(0) as usize;
   let data    = &buffer.buf[6..];
 
   if width > 64 || height > 64 {
@@ -16,7 +16,7 @@ pub fn decode_unwrapped(buffer: &Buffer) -> Result<RawImageData,String> {
       let table = {
         let mut t: [u16;256] = [0;256];
         for i in 0..256 {
-          t[i] = LEu16(data, i*2);
+          t[i] = LEu16(data, i*2).unwrap_or(0);
         }
         LookupTable::new(&t)
       };
@@ -47,7 +47,7 @@ pub fn decode_unwrapped(buffer: &Buffer) -> Result<RawImageData,String> {
     22  => {
       let mut curve: [usize;6] = [ 0, 0, 0, 0, 0, 4095 ];
       for i in 0..4 {
-        curve[i+1] = (LEu16(data, i*2) & 0xfff) as usize;
+        curve[i+1] = (LEu16(data, i*2).unwrap_or(0) & 0xfff) as usize;
       }
 
       let curve = arw::ArwDecoder::calculate_curve(curve);
@@ -55,8 +55,8 @@ pub fn decode_unwrapped(buffer: &Buffer) -> Result<RawImageData,String> {
       Ok(RawImageData::Integer(arw::ArwDecoder::decode_arw2(data, width, height, &curve, false)))
     },
     23  => {
-      let key    = LEu32(data, 0);
-      let length = LEu16(data, 4) as usize;
+      let key    = LEu32(data, 0).unwrap_or(0);
+      let length = LEu16(data, 4).unwrap_or(0) as usize;
       let data   = &data[10..];
 
       if length > 5000 {
@@ -81,7 +81,7 @@ pub fn decode_unwrapped(buffer: &Buffer) -> Result<RawImageData,String> {
       let table = {
         let mut t = [0u16;1024];
         for i in 0..1024 {
-          t[i] = LEu16(data, i*2);
+          t[i] = LEu16(data, i*2).unwrap_or(0);
         }
         LookupTable::new(&t)
       };
@@ -121,7 +121,7 @@ pub fn decode_unwrapped(buffer: &Buffer) -> Result<RawImageData,String> {
     50  => decode_nef(data, width, height, BIG_ENDIAN, 12),
     51  => decode_nef(data, width, height, BIG_ENDIAN, 14),
     52  => {
-      let coeffs = [LEf32(data,0), LEf32(data,4), LEf32(data,8), LEf32(data,12)];
+      let coeffs = [LEf32(data,0).unwrap_or(0.0), LEf32(data,4).unwrap_or(0.0), LEf32(data,8).unwrap_or(0.0), LEf32(data,12).unwrap_or(0.0)];
       let data = &data[16..];
       Ok(RawImageData::Integer(nef::NefDecoder::decode_snef_compressed(data, coeffs, width, height, false)))
     },

--- a/src/decoders/x3f.rs
+++ b/src/decoders/x3f.rs
@@ -5,7 +5,7 @@ use crate::decoders::tiff::*;
 use crate::decoders::basics::*;
 
 pub fn is_x3f(buf: &[u8]) -> bool {
-  buf[0..4] == b"FOVb"[..]
+  buf.get(0..4) == Some(&b"FOVb"[..])
 }
 
 //#[derive(Debug, Clone)]
@@ -33,13 +33,19 @@ struct X3fImage {
 
 impl X3fFile {
   fn new(buf: &Buffer) -> Result<X3fFile, String> {
-    let offset = LEu32(&buf.buf, buf.size-4) as usize;
+    if buf.size < 4 {
+      return Err("X3F: file too short".to_string())
+    }
+    let offset = LEu32(&buf.buf, buf.size-4).ok_or("X3F: can't read directory offset")? as usize;
+    if offset >= buf.size {
+      return Err(format!("X3F: directory offset {} out of bounds (size {})", offset, buf.size))
+    }
     let data = &buf.buf[offset..];
-    let version = LEu32(data, 4);
+    let version = LEu32(data, 4).ok_or("X3F: can't read directory version")?;
     if version < 0x00020000 {
       return Err(format!("X3F: Directory version too old {}", version).to_string())
     }
-    let entries = LEu32(data, 8) as usize;
+    let entries = LEu32(data, 8).ok_or("X3F: can't read directory entry count")? as usize;
     let mut dirs = Vec::new();
     let mut images = Vec::new();
     for i in 0..entries {
@@ -60,8 +66,11 @@ impl X3fFile {
 
 impl X3fDirectory {
   fn new(buf: &[u8], offset: usize) -> Result<X3fDirectory, String> {
+    if offset + 12 > buf.len() {
+      return Err(format!("X3F: directory entry at {} out of bounds", offset))
+    }
     let data = &buf[offset..];
-    let off = LEu32(data, 0) as usize;
+    let off = LEu32(data, 0).ok_or("X3F: can't read directory entry offset")? as usize;
     //let len = LEu32(data, 4) as usize;
     let name = String::from_utf8_lossy(&data[8..12]).to_string();
 
@@ -75,13 +84,16 @@ impl X3fDirectory {
 
 impl X3fImage {
   fn new(buf: &[u8], offset: usize) -> Result<X3fImage, String> {
+    if offset + 28 > buf.len() {
+      return Err(format!("X3F: image header at {} out of bounds", offset))
+    }
     let data = &buf[offset..];
 
     Ok(X3fImage {
-      typ:     LEu32(data,  8) as usize,
-      format:  LEu32(data, 12) as usize,
-      width:   LEu32(data, 16) as usize,
-      height:  LEu32(data, 20) as usize,
+      typ:     LEu32(data,  8).unwrap_or(0) as usize,
+      format:  LEu32(data, 12).unwrap_or(0) as usize,
+      width:   LEu32(data, 16).unwrap_or(0) as usize,
+      height:  LEu32(data, 20).unwrap_or(0) as usize,
       //pitch:   LEu32(data, 24) as usize,
       doffset: offset+28,
     })
@@ -96,14 +108,14 @@ pub struct X3fDecoder<'a> {
 }
 
 impl<'a> X3fDecoder<'a> {
-  pub fn new(buf: &'a Buffer, rawloader: &'a RawLoader) -> X3fDecoder<'a> {
-    let dir = X3fFile::new(buf).unwrap();
+  pub fn new(buf: &'a Buffer, rawloader: &'a RawLoader) -> Result<X3fDecoder<'a>, String> {
+    let dir = X3fFile::new(buf)?;
 
-    X3fDecoder {
+    Ok(X3fDecoder {
       buffer: &buf.buf,
       rawloader: rawloader,
       dir: dir,
-    }
+    })
   }
 }
 
@@ -113,8 +125,8 @@ impl<'a> Decoder for X3fDecoder<'a> {
         .iter()
         .find(|i| i.typ == 2 && i.format == 0x12)
         .ok_or("X3F: Couldn't find camera info".to_string())?;
-    let data = &self.buffer[caminfo.doffset+6..];
-    if data[0..4] != b"Exif"[..] {
+    let data = self.buffer.get(caminfo.doffset+6..).ok_or("X3F: camera info offset out of bounds")?;
+    if data.get(0..4) != Some(&b"Exif"[..]) {
       return Err("X3F: Couldn't find EXIF info".to_string())
     }
     let tiff = TiffIFD::new_root(self.buffer, caminfo.doffset+12)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub use decoders::cfa::CFA;
 #[doc(hidden)] pub use decoders::RawLoader;
 
 lazy_static! {
-  static ref LOADER: RawLoader = decoders::RawLoader::new();
+  static ref LOADER: RawLoader = RawLoader::new();
 }
 
 use std::path::Path;
@@ -135,4 +135,40 @@ pub fn decode_unwrapped(reader: &mut dyn Read) -> Result<RawImageData,RawLoaderE
 #[doc(hidden)]
 pub fn decode_dummy(reader: &mut dyn Read) -> Result<RawImage,RawLoaderError> {
   LOADER.decode(reader, true).map_err(|err| RawLoaderError::new(err))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::io::Cursor;
+
+  #[test]
+  fn fuzz_fuji_short_buffer() {
+    // 8-byte FUJIFILM header with no room for offsets at positions 84/92/100
+    let buf = b"FUJIFILM".to_vec();
+    let result = decode(&mut Cursor::new(&buf));
+    assert!(result.is_err());
+  }
+
+  #[test]
+  fn fuzz_x3f_malicious_offset() {
+    // FOVb magic + 0xf1 padding — directory offset reads as huge value
+    let mut buf = vec![0xf1u8; 257];
+    buf[0..4].copy_from_slice(b"FOVb");
+    let result = decode(&mut Cursor::new(&buf));
+    assert!(result.is_err());
+  }
+
+  #[test]
+  fn fuzz_tiff_large_ifd_count() {
+    // Valid TIFF LE header pointing to IFD at offset 8,
+    // IFD claims 136 entries but buffer only holds ~84
+    let mut buf = vec![0u8; 1026];
+    buf[0..2].copy_from_slice(b"II");          // little-endian
+    buf[2] = 0x2a;                              // magic 42
+    buf[4] = 0x08;                              // IFD offset = 8
+    buf[8] = 136;                               // 136 entries
+    let result = decode(&mut Cursor::new(&buf));
+    assert!(result.is_err());
+  }
 }


### PR DESCRIPTION
Fixes #54 — three fuzzing-found panics from unchecked slice indexing in the TIFF, X3F, and RAF parsers.

## Approach

The root cause is systemic: the byte-reading helpers (`BEu32`, `LEu16`, etc.) in `basics.rs` use `buf[pos..pos+N]` without bounds checking. Rather than patching three crash sites individually, this PR changes all seven helpers and both `Endian` wrapper methods to return `Option<T>`, using `buf.get()` + `from_{be,le}_bytes()`.

### Helpers changed (`basics.rs`)
`BEu32`, `LEu32`, `BEu16`, `LEu16`, `BEi32`, `LEi32`, `LEf32`, and the `Endian` methods `ru32`, `ru16`, `ri32` now return `Option` instead of panicking on out-of-bounds access.

### The three fixed panics
1. **RAF (FUJIFILM header):** `BEu32(buf, 84)` with only 8 bytes of input
2. **X3F (FOVb header):** attacker-controlled offset used as slice index
3. **TIFF (large IFD count):** IFD entry loop reads past buffer end

### Additional fixes
- `TiffEntry::new` returns `Result` — corrupt entries with OOB data pointers are skipped
- `X3fDecoder::new` returns `Result` instead of `.unwrap()`
- IFD entry loop validates `offset + 2 + num*12 + 4 <= buf.len()` upfront
- Removes `byteorder` dependency — stdlib `from_{be,le}_bytes()` (stable since Rust 1.32)

### Caller updates
- Parser code uses `.ok_or("context")?` (already returns `Result`)
- Hot-path decoder code uses `.unwrap_or(0)` (bounds already validated by container parser)

## Testing
- [x] `cargo build` compiles cleanly
- [x] `cargo test` — all tests pass (3 new regression tests + 5 existing)
- [x] Three fuzz crash inputs return `Err` instead of panicking