### PR TITLE
Add Limits for pre-allocation resource control

### DIFF
--- a/src/decoders/mod.rs
+++ b/src/decoders/mod.rs
@@ -341,6 +341,71 @@ pub fn ok_image_with_black_white(camera: Camera, width: usize, height: usize, wb
   Ok(img)
 }
 
+/// Optional resource limits for decoding.
+///
+/// Every field is `Option` so callers can set only the limits they care
+/// about. Unset fields impose no limit and add zero overhead — if all
+/// dimension fields are `None`, the extra metadata probe is skipped
+/// entirely and behavior matches `decode()`.
+///
+/// # Example
+///
+/// ```no_run
+/// use rawloader::Limits;
+///
+/// // Reject anything over 50MP without allocating the pixel buffer
+/// let limits = Limits {
+///     max_pixels: Some(50_000_000),
+///     ..Limits::default()
+/// };
+/// let image = rawloader::decode_file_with_limits("photo.cr2", &limits)?;
+/// # Ok::<(), rawloader::RawLoaderError>(())
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Limits {
+  /// Maximum total pixels (`width × height`). `None` = no limit.
+  ///
+  /// When set, `decode_with_limits` runs a cheap metadata-only pass to
+  /// get dimensions and rejects the file before allocating the pixel
+  /// buffer if `width × height` exceeds this value.
+  pub max_pixels: Option<u64>,
+
+  /// Maximum width or height in pixels. `None` = no limit.
+  ///
+  /// Checked during the same metadata probe as `max_pixels`.
+  pub max_side: Option<u64>,
+
+  /// Maximum input buffer size in bytes. `None` = no limit.
+  ///
+  /// Checked after the input is read into memory but before any decoding.
+  /// Use this to bound peak memory from the input buffer itself.
+  pub max_input_bytes: Option<u64>,
+}
+
+impl Limits {
+  /// True if any dimension limit is set. When false,
+  /// `decode_with_limits` skips the metadata probe entirely.
+  fn needs_dimension_probe(&self) -> bool {
+    self.max_pixels.is_some() || self.max_side.is_some()
+  }
+
+  fn check_dimensions(&self, width: usize, height: usize) -> Result<(), String> {
+    let (w, h) = (width as u64, height as u64);
+    if let Some(max) = self.max_pixels {
+      let pixels = w.checked_mul(h).ok_or_else(|| format!("image {}x{} overflows", w, h))?;
+      if pixels > max {
+        return Err(format!("image {}x{} = {} pixels exceeds limit of {}", w, h, pixels, max))
+      }
+    }
+    if let Some(max) = self.max_side {
+      if w > max || h > max {
+        return Err(format!("image dimension {}x{} exceeds max side {}", w, h, max))
+      }
+    }
+    Ok(())
+  }
+}
+
 /// The struct that holds all the info about the cameras and is able to decode a file
 #[derive(Debug, Clone)]
 pub struct RawLoader {
@@ -519,12 +584,48 @@ impl RawLoader {
     decoder.image(dummy)
   }
 
+  fn decode_with_limits_unsafe(&self, buffer: &Buffer, limits: &Limits) -> Result<RawImage,String> {
+    if let Some(max) = limits.max_input_bytes {
+      if buffer.size as u64 > max {
+        return Err(format!("input size {} exceeds limit of {}", buffer.size, max))
+      }
+    }
+    // Only run the metadata probe if there's a dimension limit to check.
+    // If none are set, decode_with_limits has the same overhead as decode().
+    if limits.needs_dimension_probe() {
+      let probe = self.decode_unsafe(buffer, true)?;
+      limits.check_dimensions(probe.width, probe.height)?;
+    }
+    self.decode_unsafe(buffer, false)
+  }
+
   /// Decodes an input into a RawImage
   pub fn decode(&self, reader: &mut dyn Read, dummy: bool) -> Result<RawImage,String> {
     let buffer = Buffer::new(reader)?;
 
     match panic::catch_unwind(|| {
       self.decode_unsafe(&buffer, dummy)
+    }) {
+      Ok(val) => val,
+      Err(_) => Err(format!("Caught a panic while decoding.{}", BUG).to_string()),
+    }
+  }
+
+  /// Decodes an input into a RawImage, enforcing resource limits.
+  ///
+  /// When `limits` has any dimension limit set (`max_pixels` or `max_side`),
+  /// this probes the file in dummy mode first to get dimensions, checks
+  /// them, and only then does the real decode. Files exceeding the limits
+  /// return `Err` without allocating the pixel buffer.
+  ///
+  /// When all dimension limits are `None`, no probe runs and this has the
+  /// same cost as `decode()`. Only `max_input_bytes` (a cheap size check)
+  /// is applied in that case.
+  pub fn decode_with_limits(&self, reader: &mut dyn Read, limits: &Limits) -> Result<RawImage,String> {
+    let buffer = Buffer::new(reader)?;
+
+    match panic::catch_unwind(|| {
+      self.decode_with_limits_unsafe(&buffer, limits)
     }) {
       Ok(val) => val,
       Err(_) => Err(format!("Caught a panic while decoding.{}", BUG).to_string()),
@@ -539,6 +640,16 @@ impl RawLoader {
     };
     let mut buffered_file = BufReader::new(file);
     self.decode(&mut buffered_file, false)
+  }
+
+  /// Decodes a file into a RawImage, enforcing resource limits.
+  pub fn decode_file_with_limits(&self, path: &Path, limits: &Limits) -> Result<RawImage,String> {
+    let file = match File::open(path) {
+      Ok(val) => val,
+      Err(e) => {return Err(e.to_string())},
+    };
+    let mut buffered_file = BufReader::new(file);
+    self.decode_with_limits(&mut buffered_file, limits)
   }
 
   // Decodes an unwrapped input (just the image data with minimal metadata) into a RawImage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,12 @@ pub use decoders::RawImage;
 pub use decoders::RawImageData;
 pub use decoders::Orientation;
 pub use decoders::cfa::CFA;
+pub use decoders::Limits;
 #[doc(hidden)] pub use decoders::Buffer;
 #[doc(hidden)] pub use decoders::RawLoader;
 
 lazy_static! {
-  static ref LOADER: RawLoader = decoders::RawLoader::new();
+  static ref LOADER: RawLoader = RawLoader::new();
 }
 
 use std::path::Path;
@@ -116,6 +117,33 @@ pub fn decode_file<P: AsRef<Path>>(path: P) -> Result<RawImage,RawLoaderError> {
 /// ```
 pub fn decode(reader: &mut dyn Read) -> Result<RawImage,RawLoaderError> {
   LOADER.decode(reader, false).map_err(|err| RawLoaderError::new(err))
+}
+
+/// Decode with caller-specified resource limits.
+///
+/// Every field of [`Limits`] is optional. When any dimension limit is set,
+/// the file is probed in metadata-only mode first and rejected before
+/// allocating the pixel buffer if the limits are exceeded. When no
+/// dimension limits are set, the probe is skipped and this has the same
+/// cost as [`decode`].
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let limits = rawloader::Limits {
+///     max_pixels: Some(50_000_000),
+///     ..Default::default()
+/// };
+/// let image = rawloader::decode_with_limits(&mut file, &limits)?;
+/// ```
+pub fn decode_with_limits(reader: &mut dyn Read, limits: &Limits) -> Result<RawImage,RawLoaderError> {
+  LOADER.decode_with_limits(reader, limits).map_err(|err| RawLoaderError::new(err))
+}
+
+/// Decode a file with caller-specified resource limits.
+/// See [`decode_with_limits`] for semantics.
+pub fn decode_file_with_limits<P: AsRef<Path>>(path: P, limits: &Limits) -> Result<RawImage,RawLoaderError> {
+  LOADER.decode_file_with_limits(path.as_ref(), limits).map_err(|err| RawLoaderError::new(err))
 }
 
 // Used to force lazy_static initializations. Useful for fuzzing.


### PR DESCRIPTION
## Summary

Adds caller-configurable resource limits without touching any decoder code. Every field is optional — unset limits add zero overhead.

```rust
use rawloader::Limits;

let limits = Limits {
    max_pixels: Some(50_000_000),
    ..Limits::default()
};
let image = rawloader::decode_file_with_limits("photo.cr2", &limits)?;
```

## How it works

When `limits` has any dimension limit set, `decode_with_limits` reuses the existing `dummy=true` path: it parses all the metadata, allocates only a 1-element placeholder vec, and returns a `RawImage` with `width`/`height` populated. Same code that fuzzing uses via `decode_dummy`.

The flow:
1. **Probe:** `decode_unsafe(buffer, true)` — full metadata parse, no pixel allocation
2. **Validate:** check dimensions against limits
3. **Real decode:** `decode_unsafe(buffer, false)` only if dimensions fit

Rejected files never allocate the pixel buffer. Metadata parsing happens twice but it's cheap (microseconds) compared to the actual decode.

When all dimension limits are `None`, the probe is skipped entirely and `decode_with_limits` has the same cost as `decode()`. Only `max_input_bytes` (a cheap size check) is applied in that case.

## What this doesn't change

- Existing `decode`, `decode_file`, `decode_dummy`, `decode_unwrapped` are untouched
- No decoder code, no macros, no `decode_threaded`, no packed functions
- The internal `alloc_image_plain!` 500M/50k panic still acts as a backstop for code paths that don't go through `decode_with_limits`

## Public API additions

```rust
pub struct Limits {
    pub max_pixels: Option<u64>,
    pub max_side: Option<u64>,
    pub max_input_bytes: Option<u64>,
}

pub fn decode_with_limits(reader: &mut dyn Read, limits: &Limits) -> Result<RawImage, RawLoaderError>;
pub fn decode_file_with_limits<P: AsRef<Path>>(path: P, limits: &Limits) -> Result<RawImage, RawLoaderError>;
```

## Diff

140 insertions / 1 deletion across 2 files (`src/decoders/mod.rs`, `src/lib.rs`).

The 1 deletion is an unrelated single-line clippy fix (`decoders::RawLoader::new()` → `RawLoader::new()`) that was preventing clean compile on master.